### PR TITLE
add support for gpx desc metadata

### DIFF
--- a/lib/gpx/gpx_file.rb
+++ b/lib/gpx/gpx_file.rb
@@ -22,7 +22,7 @@
 #++
 module GPX
   class GPXFile < Base
-    attr_accessor :tracks, :routes, :waypoints, :bounds, :lowest_point, :highest_point, :duration, :ns, :time, :name, :version, :creator
+    attr_accessor :tracks, :routes, :waypoints, :bounds, :lowest_point, :highest_point, :duration, :ns, :time, :name, :version, :creator, :description
 
     DEFAULT_CREATOR = "GPX RubyGem #{GPX::VERSION} -- http://dougfales.github.io/gpx/".freeze
 
@@ -76,6 +76,7 @@ module GPX
 
         @time = Time.parse(@xml.at("metadata/time").inner_text) rescue nil
         @name = @xml.at("metadata/name").inner_text rescue nil
+        @description = @xml.at('metadata/desc').inner_text rescue nil
         @tracks = []
         @xml.search("trk").each do |trk|
           trk = Track.new(:element => trk, :gpx_file => self)

--- a/tests/gpx_file_test.rb
+++ b/tests/gpx_file_test.rb
@@ -9,40 +9,42 @@ class GPXFileTest < Minitest::Test
 
   def test_load_data_from_string
     gpx_file = GPX::GPXFile.new(:gpx_data => open(ONE_TRACK_FILE).read)
-	assert_equal(1, gpx_file.tracks.size)
-	assert_equal(8, gpx_file.tracks.first.segments.size)
-	assert_equal("ACTIVE LOG", gpx_file.tracks.first.name)
-	assert_equal("active_log.gpx", gpx_file.name)
-	assert_equal("2006-04-08T16:44:28Z", gpx_file.time.xmlschema)
-	assert_equal(38.681488, gpx_file.bounds.min_lat)
-	assert_equal(-109.606948, gpx_file.bounds.min_lon)
-	assert_equal(38.791759, gpx_file.bounds.max_lat)
-	assert_equal(-109.447045, gpx_file.bounds.max_lon)
+    assert_equal(1, gpx_file.tracks.size)
+    assert_equal(8, gpx_file.tracks.first.segments.size)
+    assert_equal("ACTIVE LOG", gpx_file.tracks.first.name)
+    assert_equal("active_log.gpx", gpx_file.name)
+    assert_equal("2006-04-08T16:44:28Z", gpx_file.time.xmlschema)
+    assert_equal(38.681488, gpx_file.bounds.min_lat)
+    assert_equal(-109.606948, gpx_file.bounds.min_lon)
+    assert_equal(38.791759, gpx_file.bounds.max_lat)
+    assert_equal(-109.447045, gpx_file.bounds.max_lon)
+    assert_equal('description of my GPX file with special char like &, <, >', gpx_file.description)
   end
 
   def test_load_data_from_file
     gpx_file = GPX::GPXFile.new(:gpx_file => ONE_TRACK_FILE)
-	assert_equal(1, gpx_file.tracks.size)
-	assert_equal(8, gpx_file.tracks.first.segments.size)
-	assert_equal("ACTIVE LOG", gpx_file.tracks.first.name)
-	assert_equal("active_log.gpx", gpx_file.name)
-	assert_equal("2006-04-08T16:44:28Z", gpx_file.time.xmlschema)
-	assert_equal(38.681488, gpx_file.bounds.min_lat)
-	assert_equal(-109.606948, gpx_file.bounds.min_lon)
-	assert_equal(38.791759, gpx_file.bounds.max_lat)
-	assert_equal(-109.447045, gpx_file.bounds.max_lon)
+    assert_equal(1, gpx_file.tracks.size)
+    assert_equal(8, gpx_file.tracks.first.segments.size)
+    assert_equal("ACTIVE LOG", gpx_file.tracks.first.name)
+    assert_equal("active_log.gpx", gpx_file.name)
+    assert_equal("2006-04-08T16:44:28Z", gpx_file.time.xmlschema)
+    assert_equal(38.681488, gpx_file.bounds.min_lat)
+    assert_equal(-109.606948, gpx_file.bounds.min_lon)
+    assert_equal(38.791759, gpx_file.bounds.max_lat)
+    assert_equal(-109.447045, gpx_file.bounds.max_lon)
+    assert_equal('description of my GPX file with special char like &, <, >', gpx_file.description)
   end
 
   def test_big_file
     gpx_file = GPX::GPXFile.new(:gpx_file => BIG_FILE)
-	assert_equal(1, gpx_file.tracks.size)
-	assert_equal(7968, gpx_file.tracks.first.points.size)
+    assert_equal(1, gpx_file.tracks.size)
+    assert_equal(7968, gpx_file.tracks.first.points.size)
   end
 
   def test_with_or_with_elev
     gpx_file = GPX::GPXFile.new(:gpx_file => WITH_OR_WITHOUT_ELEV_FILE)
-	assert_equal(2, gpx_file.tracks.size)
-	#assert_equal(7968, gpx_file.tracks.first.points.size)
+    assert_equal(2, gpx_file.tracks.size)
+    #assert_equal(7968, gpx_file.tracks.first.points.size)
   end
 
 end

--- a/tests/gpx_files/one_track.gpx
+++ b/tests/gpx_files/one_track.gpx
@@ -2,7 +2,8 @@
 <gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="Link2GPS - 2.0.2 - http://www.hiketech.com" xsi:schemaLocation="ttp://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
 	<metadata>
 		<name><![CDATA[active_log.gpx]]></name>
-		<time>2006-04-08T16:44:28Z</time>
+    <desc><![CDATA[description of my GPX file with special char like &, <, >]]></desc>
+    <time>2006-04-08T16:44:28Z</time>
 		<bounds min_lat="38.681488" min_lon="-109.606948" max_lat="38.791759" max_lon="-109.447045"/>
 	</metadata>
 	<extensions/>


### PR DESCRIPTION
This PR add support for the desc field in of the gpx metadata.
Test suite updated to check this (with replace of tab by space to allow proper indentation).