### PR TITLE
Enhance calculation of average speed (with usage of new moving_duration)

### DIFF
--- a/lib/gpx/segment.rb
+++ b/lib/gpx/segment.rb
@@ -72,7 +72,7 @@ module GPX
       @bounds.max_lon = pt.lon if pt.lon > @bounds.max_lon
       unless last_pt.nil?
         @distance += haversine_distance(last_pt, pt)
-        @duration += pt.time - last_pt.time
+        @duration += pt.time - last_pt.time unless pt.time.nil? or last_pt.time.nil?
       end
       @points << pt
     end
@@ -251,7 +251,7 @@ module GPX
       @bounds.add(pt)
       unless last_pt.nil?
         @distance += haversine_distance(last_pt, pt)
-        @duration += pt.time - last_pt.time
+        @duration += pt.time - last_pt.time unless pt.time.nil? or last_pt.time.nil?
       end
     end
 

--- a/lib/gpx/segment.rb
+++ b/lib/gpx/segment.rb
@@ -58,7 +58,7 @@ module GPX
     # Tack on a point to this Segment.  All meta-data will be updated.
     def append_point(pt)
       last_pt = @points[-1]
-      unless pt.time.nil?
+      if pt.time
         @earliest_point = pt if(@earliest_point.nil? or pt.time < @earliest_point.time)
         @latest_point   = pt if(@latest_point.nil? or pt.time > @latest_point.time)
       else
@@ -67,7 +67,7 @@ module GPX
         @latest_point = pt
       end
 
-      unless pt.elevation.nil?
+      if pt.elevation
         @lowest_point   = pt if(@lowest_point.nil? or pt.elevation < @lowest_point.elevation)
         @highest_point  = pt if(@highest_point.nil? or pt.elevation > @highest_point.elevation)
       end
@@ -75,9 +75,9 @@ module GPX
       @bounds.min_lon = pt.lon if pt.lon < @bounds.min_lon
       @bounds.max_lat = pt.lat if pt.lat > @bounds.max_lat
       @bounds.max_lon = pt.lon if pt.lon > @bounds.max_lon
-      unless last_pt.nil?
+      if last_pt
         @distance += haversine_distance(last_pt, pt)
-        @duration += pt.time - last_pt.time unless pt.time.nil? or last_pt.time.nil?
+        @duration += pt.time - last_pt.time if pt.time and last_pt.time
       end
       @points << pt
     end
@@ -245,7 +245,7 @@ module GPX
     end
 
     def update_meta_data(pt, last_pt)
-      unless pt.time.nil?
+      if pt.time
         @earliest_point = pt if(@earliest_point.nil? or pt.time < @earliest_point.time)
         @latest_point   = pt if(@latest_point.nil? or pt.time > @latest_point.time)
       else
@@ -254,14 +254,14 @@ module GPX
         @latest_point = @points[-1]
       end
 
-      unless pt.elevation.nil?
+      if pt.elevation
         @lowest_point   = pt if(@lowest_point.nil? or pt.elevation < @lowest_point.elevation)
         @highest_point  = pt if(@highest_point.nil? or pt.elevation > @highest_point.elevation)
       end
       @bounds.add(pt)
-      unless last_pt.nil?
+      if last_pt
         @distance += haversine_distance(last_pt, pt)
-        @duration += pt.time - last_pt.time unless pt.time.nil? or last_pt.time.nil?
+        @duration += pt.time - last_pt.time if pt.time and last_pt.time
       end
     end
 

--- a/lib/gpx/segment.rb
+++ b/lib/gpx/segment.rb
@@ -27,7 +27,7 @@ module GPX
   # latest points, distance, and bounds.
   class Segment < Base
 
-    attr_reader :earliest_point, :latest_point, :bounds, :highest_point, :lowest_point, :distance
+    attr_reader :earliest_point, :latest_point, :bounds, :highest_point, :lowest_point, :distance, :duration
     attr_accessor :points, :track
 
     # If a XML::Node object is passed-in, this will initialize a new
@@ -41,6 +41,7 @@ module GPX
       @highest_point = nil
       @lowest_point = nil
       @distance = 0.0
+      @duration = 0.0
       @bounds = Bounds.new
       if(opts[:element])
         segment_element = opts[:element]
@@ -69,7 +70,10 @@ module GPX
       @bounds.min_lon = pt.lon if pt.lon < @bounds.min_lon
       @bounds.max_lat = pt.lat if pt.lat > @bounds.max_lat
       @bounds.max_lon = pt.lon if pt.lon > @bounds.max_lon
-      @distance += haversine_distance(last_pt, pt) unless last_pt.nil?
+      unless last_pt.nil?
+        @distance += haversine_distance(last_pt, pt)
+        @duration += pt.time - last_pt.time
+      end
       @points << pt
     end
 
@@ -181,7 +185,6 @@ module GPX
         tmp_points.push tmp_point
       end
       last_pt = nil
-      @distance = 0
       @points.clear
       reset_meta_data
       #now commit the averages back and recalculate the distances
@@ -232,6 +235,7 @@ module GPX
       @highest_point = nil
       @lowest_point = nil
       @distance = 0.0
+      @duration = 0.0
       @bounds = Bounds.new
     end
 
@@ -245,7 +249,10 @@ module GPX
         @highest_point  = pt if(@highest_point.nil? or pt.elevation > @highest_point.elevation)
       end
       @bounds.add(pt)
-      @distance += haversine_distance(last_pt, pt) unless last_pt.nil?
+      unless last_pt.nil?
+        @distance += haversine_distance(last_pt, pt)
+        @duration += pt.time - last_pt.time
+      end
     end
 
   end

--- a/lib/gpx/segment.rb
+++ b/lib/gpx/segment.rb
@@ -61,7 +61,12 @@ module GPX
       unless pt.time.nil?
         @earliest_point = pt if(@earliest_point.nil? or pt.time < @earliest_point.time)
         @latest_point   = pt if(@latest_point.nil? or pt.time > @latest_point.time)
+      else
+        # when no time information in data, we consider the points are ordered
+        @earliest_point = @points[0]
+        @latest_point = pt
       end
+
       unless pt.elevation.nil?
         @lowest_point   = pt if(@lowest_point.nil? or pt.elevation < @lowest_point.elevation)
         @highest_point  = pt if(@highest_point.nil? or pt.elevation > @highest_point.elevation)
@@ -243,7 +248,12 @@ module GPX
       unless pt.time.nil?
         @earliest_point = pt if(@earliest_point.nil? or pt.time < @earliest_point.time)
         @latest_point   = pt if(@latest_point.nil? or pt.time > @latest_point.time)
+      else
+        # when no time information in data, we consider the points are ordered
+        @earliest_point = @points[0]
+        @latest_point = @points[-1]
       end
+
       unless pt.elevation.nil?
         @lowest_point   = pt if(@lowest_point.nil? or pt.elevation < @lowest_point.elevation)
         @highest_point  = pt if(@highest_point.nil? or pt.elevation > @highest_point.elevation)

--- a/lib/gpx/track.rb
+++ b/lib/gpx/track.rb
@@ -28,7 +28,7 @@ module GPX
   # array of the segments that copmrise it, but additionally each track holds
   # a reference to all of its points as one big array called "points".
   class Track < Base
-    attr_reader :points, :bounds, :lowest_point, :highest_point, :distance
+    attr_reader :points, :bounds, :lowest_point, :highest_point, :distance, :moving_duration
     attr_accessor :segments, :name, :gpx_file
 
     # Initialize a track from a XML::Node, or, if no :element option is
@@ -108,6 +108,7 @@ module GPX
       result << "\tSize: #{points.size} points\n"
       result << "\tSegments: #{segments.size} \n"
       result << "\tDistance: #{distance} km\n"
+      result << "\tMoving duration: #{moving_duration} km\n"
       result << "\tLowest Point: #{lowest_point.elevation} \n"
       result << "\tHighest Point: #{highest_point.elevation}\n "
       result << "\tBounds: #{bounds.to_s}"
@@ -128,6 +129,7 @@ module GPX
       @highest_point  = seg.highest_point if(@highest_point.nil? or seg.highest_point.elevation > @highest_point.elevation)
       @bounds.add(seg.bounds)
       @distance += seg.distance
+      @moving_duration += seg.duration
       @points.concat(seg.points)
     end
 
@@ -136,6 +138,7 @@ module GPX
       @highest_point = nil
       @lowest_point = nil
       @distance = 0.0
+      @moving_duration = 0.0
       @points = []
     end
 

--- a/lib/gpx/track.rb
+++ b/lib/gpx/track.rb
@@ -28,7 +28,7 @@ module GPX
   # array of the segments that copmrise it, but additionally each track holds
   # a reference to all of its points as one big array called "points".
   class Track < Base
-    attr_reader :points, :bounds, :lowest_point, :highest_point, :distance, :moving_duration
+    attr_reader :points, :bounds, :lowest_point, :highest_point, :distance, :moving_duration, :comment, :description
     attr_accessor :segments, :name, :gpx_file
 
     # Initialize a track from a XML::Node, or, if no :element option is
@@ -41,6 +41,8 @@ module GPX
       if(opts[:element])
         trk_element = opts[:element]
         @name = (trk_element.at("name").inner_text rescue "")
+        @comment = (trk_element.at('cmt').inner_text rescue '')
+        @description = (trk_element.at('desc').inner_text rescue '')
         trk_element.search("trkseg").each do |seg_element|
           seg = Segment.new(:element => seg_element, :track => self, :gpx_file => @gpx_file)
           update_meta_data(seg)
@@ -105,6 +107,8 @@ module GPX
     def to_s
       result = "Track \n"
       result << "\tName: #{name}\n"
+      result << "\tComment: #{comment}\n"
+      result << "\tDescription: #{description}\n"
       result << "\tSize: #{points.size} points\n"
       result << "\tSegments: #{segments.size} \n"
       result << "\tDistance: #{distance} km\n"

--- a/tests/gpx_file_test.rb
+++ b/tests/gpx_file_test.rb
@@ -19,6 +19,11 @@ class GPXFileTest < Minitest::Test
     assert_equal(38.791759, gpx_file.bounds.max_lat)
     assert_equal(-109.447045, gpx_file.bounds.max_lon)
     assert_equal('description of my GPX file with special char like &, <, >', gpx_file.description)
+    assert_equal('description of my GPX file with special char like &, <, >', gpx_file.description)
+    assert_equal(3.0724966849262554, gpx_file.distance)
+    assert_equal(15237.0, gpx_file.duration)
+    assert_equal(3036.0, gpx_file.moving_duration)
+    assert_equal(3.6432767014935834, gpx_file.average_speed)
   end
 
   def test_load_data_from_file
@@ -33,17 +38,27 @@ class GPXFileTest < Minitest::Test
     assert_equal(38.791759, gpx_file.bounds.max_lat)
     assert_equal(-109.447045, gpx_file.bounds.max_lon)
     assert_equal('description of my GPX file with special char like &, <, >', gpx_file.description)
+    assert_equal(3.0724966849262554, gpx_file.distance)
+    assert_equal(15237.0, gpx_file.duration)
+    assert_equal(3036.0, gpx_file.moving_duration)
+    assert_equal(3.6432767014935834, gpx_file.average_speed)
   end
 
   def test_big_file
     gpx_file = GPX::GPXFile.new(:gpx_file => BIG_FILE)
     assert_equal(1, gpx_file.tracks.size)
     assert_equal(7968, gpx_file.tracks.first.points.size)
+    assert_equal(105508.0, gpx_file.duration)
+    assert_equal(57645.0, gpx_file.moving_duration)
+    assert_in_delta(99.60738958686505, gpx_file.average_speed, 1e-13)
   end
 
   def test_with_or_with_elev
     gpx_file = GPX::GPXFile.new(:gpx_file => WITH_OR_WITHOUT_ELEV_FILE)
     assert_equal(2, gpx_file.tracks.size)
+    assert_equal(0, gpx_file.duration)
+    assert_equal(0, gpx_file.moving_duration)
+    assert(gpx_file.average_speed.nan?)
     #assert_equal(7968, gpx_file.tracks.first.points.size)
   end
 

--- a/tests/gpx_files/one_segment_no_time.gpx
+++ b/tests/gpx_files/one_segment_no_time.gpx
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="Link2GPS - 2.0.2 - http://www.hiketech.com" xsi:schemaLocation="ttp://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+	<metadata>
+		<name><![CDATA[rabbit_valley.gpx]]></name>
+		<bounds min_lat="39.173834" min_lon="-109.016604" max_lat="39.188747" max_lon="-108.999546"/>
+	</metadata>
+	<extensions/>
+	<trk>
+		<name><![CDATA[RABBIT U]]></name>
+		<trkseg>
+			<trkpt lat="39.185185" lon="-109.016433">
+				<ele>1334.447</ele>
+			</trkpt>
+			<trkpt lat="39.185143" lon="-109.016433">
+				<ele>1338.292</ele>
+			</trkpt>
+			<trkpt lat="39.185143" lon="-109.016433">
+				<ele>1344.061</ele>
+			</trkpt>
+			<trkpt lat="39.185143" lon="-109.016433">
+				<ele>1364.729</ele>
+			</trkpt>
+			<trkpt lat="39.185121" lon="-109.016433">
+				<ele>1371.938</ele>
+			</trkpt>
+			<trkpt lat="39.185121" lon="-109.016433">
+				<ele>1375.303</ele>
+			</trkpt>
+			<trkpt lat="39.185121" lon="-109.016433">
+				<ele>1389.723</ele>
+			</trkpt>
+			<trkpt lat="39.185121" lon="-109.016433">
+				<ele>1396.452</ele>
+			</trkpt>
+			<trkpt lat="39.185143" lon="-109.016433">
+				<ele>1400.778</ele>
+			</trkpt>
+			<trkpt lat="39.185143" lon="-109.016433">
+				<ele>1404.143</ele>
+			</trkpt>
+			<trkpt lat="39.185143" lon="-109.016433">
+				<ele>1410.391</ele>
+			</trkpt>
+			<trkpt lat="39.185143" lon="-109.016433">
+				<ele>1413.756</ele>
+			</trkpt>
+			<trkpt lat="39.185164" lon="-109.016454">
+				<ele>1414.237</ele>
+			</trkpt>
+			<trkpt lat="39.185271" lon="-109.016476">
+				<ele>1415.679</ele>
+			</trkpt>
+			<trkpt lat="39.185207" lon="-109.016497">
+				<ele>1415.679</ele>
+			</trkpt>
+			<trkpt lat="39.185228" lon="-109.016476">
+				<ele>1415.679</ele>
+			</trkpt>
+			<trkpt lat="39.185271" lon="-109.016519">
+				<ele>1415.198</ele>
+			</trkpt>
+			<trkpt lat="39.185228" lon="-109.016562">
+				<ele>1414.717</ele>
+			</trkpt>
+			<trkpt lat="39.185207" lon="-109.016476">
+				<ele>1415.679</ele>
+			</trkpt>
+			<trkpt lat="39.185185" lon="-109.016562">
+				<ele>1415.679</ele>
+			</trkpt>
+			<trkpt lat="39.185164" lon="-109.016562">
+				<ele>1415.679</ele>
+			</trkpt>
+			<trkpt lat="39.184735" lon="-109.016411">
+				<ele>1415.198</ele>
+			</trkpt>
+			<trkpt lat="39.184864" lon="-109.016368">
+				<ele>1415.679</ele>
+			</trkpt>
+			<trkpt lat="39.184928" lon="-109.016283">
+				<ele>1415.198</ele>
+			</trkpt>
+			<trkpt lat="39.185121" lon="-109.015746">
+				<ele>1416.159</ele>
+			</trkpt>
+			<trkpt lat="39.185357" lon="-109.015231">
+				<ele>1417.601</ele>
+			</trkpt>
+			<trkpt lat="39.185572" lon="-109.014802">
+				<ele>1417.601</ele>
+			</trkpt>
+			<trkpt lat="39.185593" lon="-109.014802">
+				<ele>1417.601</ele>
+			</trkpt>
+			<trkpt lat="39.185143" lon="-109.015725">
+				<ele>1417.601</ele>
+			</trkpt>
+			<trkpt lat="39.184928" lon="-109.016497">
+				<ele>1415.679</ele>
+			</trkpt>
+			<trkpt lat="39.185164" lon="-109.016540">
+				<ele>1416.159</ele>
+			</trkpt>
+			<trkpt lat="39.185164" lon="-109.016540">
+				<ele>1415.679</ele>
+			</trkpt>
+			<trkpt lat="39.185185" lon="-109.016540">
+				<ele>1413.756</ele>
+			</trkpt>
+			<trkpt lat="39.185164" lon="-109.016540">
+				<ele>1414.237</ele>
+			</trkpt>
+			<trkpt lat="39.185185" lon="-109.016497">
+				<ele>1414.237</ele>
+			</trkpt>
+			<trkpt lat="39.184992" lon="-109.016497">
+				<ele>1414.717</ele>
+			</trkpt>
+			<trkpt lat="39.184949" lon="-109.016283">
+				<ele>1415.198</ele>
+			</trkpt>
+			<trkpt lat="39.184992" lon="-109.016197">
+				<ele>1414.237</ele>
+			</trkpt>
+			<trkpt lat="39.185207" lon="-109.015596">
+				<ele>1418.082</ele>
+			</trkpt>
+			<trkpt lat="39.185593" lon="-109.014781">
+				<ele>1418.562</ele>
+			</trkpt>
+			<trkpt lat="39.185636" lon="-109.014652">
+				<ele>1417.121</ele>
+			</trkpt>
+			<trkpt lat="39.185593" lon="-109.014587">
+				<ele>1416.64</ele>
+			</trkpt>
+			<trkpt lat="39.185379" lon="-109.014523">
+				<ele>1419.043</ele>
+			</trkpt>
+			<trkpt lat="39.185078" lon="-109.014480">
+				<ele>1419.043</ele>
+			</trkpt>
+			<trkpt lat="39.184628" lon="-109.014266">
+				<ele>1416.159</ele>
+			</trkpt>
+			<trkpt lat="39.184155" lon="-109.013836">
+				<ele>1415.198</ele>
+			</trkpt>
+			<trkpt lat="39.183791" lon="-109.013665">
+				<ele>1414.717</ele>
+			</trkpt>
+			<trkpt lat="39.183018" lon="-109.013150">
+				<ele>1411.353</ele>
+			</trkpt>
+			<trkpt lat="39.182611" lon="-109.012806">
+				<ele>1409.911</ele>
+			</trkpt>
+			<trkpt lat="39.182053" lon="-109.012463">
+				<ele>1409.43</ele>
+			</trkpt>
+			<trkpt lat="39.181623" lon="-109.012463">
+				<ele>1408.469</ele>
+			</trkpt>
+			<trkpt lat="39.181173" lon="-109.012377">
+				<ele>1407.027</ele>
+			</trkpt>
+			<trkpt lat="39.180572" lon="-109.012098">
+				<ele>1403.662</ele>
+			</trkpt>
+			<trkpt lat="39.180572" lon="-109.012098">
+				<ele>1402.701</ele>
+			</trkpt>
+			<trkpt lat="39.180980" lon="-109.012270">
+				<ele>1406.065</ele>
+			</trkpt>
+			<trkpt lat="39.181516" lon="-109.012442">
+				<ele>1407.508</ele>
+			</trkpt>
+			<trkpt lat="39.181795" lon="-109.012420">
+				<ele>1408.469</ele>
+			</trkpt>
+			<trkpt lat="39.182010" lon="-109.012098">
+				<ele>1408.469</ele>
+			</trkpt>
+			<trkpt lat="39.182417" lon="-109.011734">
+				<ele>1409.43</ele>
+			</trkpt>
+			<trkpt lat="39.182675" lon="-109.011455">
+				<ele>1409.43</ele>
+			</trkpt>
+			<trkpt lat="39.183040" lon="-109.011133">
+				<ele>1411.353</ele>
+			</trkpt>
+			<trkpt lat="39.183340" lon="-109.010768">
+				<ele>1411.833</ele>
+			</trkpt>
+			<trkpt lat="39.183555" lon="-109.010468">
+				<ele>1412.314</ele>
+			</trkpt>
+			<trkpt lat="39.183576" lon="-109.010403">
+				<ele>1411.833</ele>
+			</trkpt>
+			<trkpt lat="39.183490" lon="-109.010253">
+				<ele>1412.314</ele>
+			</trkpt>
+			<trkpt lat="39.183040" lon="-109.010017">
+				<ele>1409.911</ele>
+			</trkpt>
+			<trkpt lat="39.182954" lon="-109.009759">
+				<ele>1410.391</ele>
+			</trkpt>
+			<trkpt lat="39.183104" lon="-109.009287">
+				<ele>1409.911</ele>
+			</trkpt>
+			<trkpt lat="39.183168" lon="-109.008901">
+				<ele>1408.469</ele>
+			</trkpt>
+			<trkpt lat="39.183104" lon="-109.008794">
+				<ele>1407.027</ele>
+			</trkpt>
+			<trkpt lat="39.182847" lon="-109.008622">
+				<ele>1408.469</ele>
+			</trkpt>
+			<trkpt lat="39.182568" lon="-109.008386">
+				<ele>1411.353</ele>
+			</trkpt>
+			<trkpt lat="39.182396" lon="-109.008107">
+				<ele>1411.353</ele>
+			</trkpt>
+			<trkpt lat="39.182181" lon="-109.007485">
+				<ele>1414.237</ele>
+			</trkpt>
+			<trkpt lat="39.181924" lon="-109.006777">
+				<ele>1416.159</ele>
+			</trkpt>
+			<trkpt lat="39.181602" lon="-109.005575">
+				<ele>1416.64</ele>
+			</trkpt>
+			<trkpt lat="39.181881" lon="-109.003923">
+				<ele>1419.524</ele>
+			</trkpt>
+			<trkpt lat="39.181924" lon="-109.003301">
+				<ele>1420.485</ele>
+			</trkpt>
+			<trkpt lat="39.181709" lon="-109.002807">
+				<ele>1421.447</ele>
+			</trkpt>
+			<trkpt lat="39.181387" lon="-109.002571">
+				<ele>1424.331</ele>
+			</trkpt>
+			<trkpt lat="39.180851" lon="-109.002357">
+				<ele>1425.772</ele>
+			</trkpt>
+			<trkpt lat="39.180465" lon="-109.002035">
+				<ele>1427.695</ele>
+			</trkpt>
+			<trkpt lat="39.180379" lon="-109.001606">
+				<ele>1428.656</ele>
+			</trkpt>
+			<trkpt lat="39.180207" lon="-109.001198">
+				<ele>1430.579</ele>
+			</trkpt>
+			<trkpt lat="39.180057" lon="-109.001133">
+				<ele>1429.137</ele>
+			</trkpt>
+			<trkpt lat="39.180100" lon="-109.001112">
+				<ele>1429.618</ele>
+			</trkpt>
+			<trkpt lat="39.180100" lon="-109.001133">
+				<ele>1428.176</ele>
+			</trkpt>
+			<trkpt lat="39.178984" lon="-109.001412">
+				<ele>1433.463</ele>
+			</trkpt>
+			<trkpt lat="39.178491" lon="-109.001348">
+				<ele>1433.944</ele>
+			</trkpt>
+			<trkpt lat="39.177632" lon="-109.001391">
+				<ele>1438.27</ele>
+			</trkpt>
+			<trkpt lat="39.177010" lon="-109.001498">
+				<ele>1445.479</ele>
+			</trkpt>
+			<trkpt lat="39.176774" lon="-109.001584">
+				<ele>1451.728</ele>
+			</trkpt>
+			<trkpt lat="39.176452" lon="-109.001520">
+				<ele>1454.132</ele>
+			</trkpt>
+			<trkpt lat="39.176345" lon="-109.001584">
+				<ele>1455.573</ele>
+			</trkpt>
+			<trkpt lat="39.176259" lon="-109.001820">
+				<ele>1457.015</ele>
+			</trkpt>
+			<trkpt lat="39.176152" lon="-109.001949">
+				<ele>1458.457</ele>
+			</trkpt>
+			<trkpt lat="39.175916" lon="-109.002013">
+				<ele>1461.341</ele>
+			</trkpt>
+			<trkpt lat="39.175766" lon="-109.001927">
+				<ele>1463.264</ele>
+			</trkpt>
+			<trkpt lat="39.175594" lon="-109.001863">
+				<ele>1467.109</ele>
+			</trkpt>
+			<trkpt lat="39.175422" lon="-109.001756">
+				<ele>1469.032</ele>
+			</trkpt>
+			<trkpt lat="39.175444" lon="-109.001756">
+				<ele>1469.032</ele>
+			</trkpt>
+			<trkpt lat="39.175379" lon="-109.001713">
+				<ele>1469.993</ele>
+			</trkpt>
+			<trkpt lat="39.175122" lon="-109.001455">
+				<ele>1471.916</ele>
+			</trkpt>
+			<trkpt lat="39.174886" lon="-109.001005">
+				<ele>1469.993</ele>
+			</trkpt>
+			<trkpt lat="39.174864" lon="-109.000769">
+				<ele>1468.551</ele>
+			</trkpt>
+			<trkpt lat="39.174650" lon="-109.000533">
+				<ele>1469.032</ele>
+			</trkpt>
+			<trkpt lat="39.174092" lon="-108.999996">
+				<ele>1474.319</ele>
+			</trkpt>
+			<trkpt lat="39.173985" lon="-108.999803">
+				<ele>1476.242</ele>
+			</trkpt>
+			<trkpt lat="39.173834" lon="-108.999546">
+				<ele>1480.087</ele>
+			</trkpt>
+			<trkpt lat="39.173834" lon="-108.999588">
+				<ele>1478.645</ele>
+			</trkpt>
+			<trkpt lat="39.173963" lon="-108.999760">
+				<ele>1478.164</ele>
+			</trkpt>
+			<trkpt lat="39.174092" lon="-108.999975">
+				<ele>1474.319</ele>
+			</trkpt>
+			<trkpt lat="39.174156" lon="-109.000061">
+				<ele>1472.396</ele>
+			</trkpt>
+			<trkpt lat="39.174178" lon="-109.000061">
+				<ele>1471.435</ele>
+			</trkpt>
+			<trkpt lat="39.174178" lon="-109.000103">
+				<ele>1471.916</ele>
+			</trkpt>
+			<trkpt lat="39.174178" lon="-109.000082">
+				<ele>1473.358</ele>
+			</trkpt>
+			<trkpt lat="39.174414" lon="-109.000275">
+				<ele>1470.955</ele>
+			</trkpt>
+			<trkpt lat="39.174500" lon="-109.000382">
+				<ele>1469.993</ele>
+			</trkpt>
+			<trkpt lat="39.174736" lon="-109.000576">
+				<ele>1468.071</ele>
+			</trkpt>
+			<trkpt lat="39.174864" lon="-109.000790">
+				<ele>1468.551</ele>
+			</trkpt>
+			<trkpt lat="39.174993" lon="-109.001155">
+				<ele>1471.435</ele>
+			</trkpt>
+			<trkpt lat="39.174950" lon="-109.001155">
+				<ele>1471.435</ele>
+			</trkpt>
+			<trkpt lat="39.174972" lon="-109.001155">
+				<ele>1468.071</ele>
+			</trkpt>
+			<trkpt lat="39.174972" lon="-109.001155">
+				<ele>1472.877</ele>
+			</trkpt>
+			<trkpt lat="39.174993" lon="-109.001176">
+				<ele>1469.513</ele>
+			</trkpt>
+			<trkpt lat="39.174993" lon="-109.001133">
+				<ele>1470.474</ele>
+			</trkpt>
+			<trkpt lat="39.174972" lon="-109.001176">
+				<ele>1471.435</ele>
+			</trkpt>
+			<trkpt lat="39.175208" lon="-109.001541">
+				<ele>1471.435</ele>
+			</trkpt>
+			<trkpt lat="39.175508" lon="-109.001799">
+				<ele>1468.551</ele>
+			</trkpt>
+			<trkpt lat="39.175680" lon="-109.001863">
+				<ele>1465.667</ele>
+			</trkpt>
+			<trkpt lat="39.175766" lon="-109.001949">
+				<ele>1462.302</ele>
+			</trkpt>
+			<trkpt lat="39.175894" lon="-109.002013">
+				<ele>1461.341</ele>
+			</trkpt>
+			<trkpt lat="39.176023" lon="-109.002035">
+				<ele>1459.899</ele>
+			</trkpt>
+			<trkpt lat="39.176280" lon="-109.001799">
+				<ele>1457.977</ele>
+			</trkpt>
+			<trkpt lat="39.176366" lon="-109.001606">
+				<ele>1456.054</ele>
+			</trkpt>
+			<trkpt lat="39.176431" lon="-109.001541">
+				<ele>1455.093</ele>
+			</trkpt>
+			<trkpt lat="39.176495" lon="-109.001520">
+				<ele>1453.651</ele>
+			</trkpt>
+			<trkpt lat="39.176838" lon="-109.001541">
+				<ele>1449.805</ele>
+			</trkpt>
+			<trkpt lat="39.176967" lon="-109.001498">
+				<ele>1446.921</ele>
+			</trkpt>
+			<trkpt lat="39.177954" lon="-109.001391">
+				<ele>1437.308</ele>
+			</trkpt>
+			<trkpt lat="39.178534" lon="-109.001369">
+				<ele>1435.385</ele>
+			</trkpt>
+			<trkpt lat="39.178941" lon="-109.001434">
+				<ele>1434.424</ele>
+			</trkpt>
+			<trkpt lat="39.180057" lon="-109.001176">
+				<ele>1432.021</ele>
+			</trkpt>
+			<trkpt lat="39.180207" lon="-109.001176">
+				<ele>1430.579</ele>
+			</trkpt>
+			<trkpt lat="39.180357" lon="-109.001412">
+				<ele>1429.618</ele>
+			</trkpt>
+			<trkpt lat="39.180443" lon="-109.001970">
+				<ele>1427.215</ele>
+			</trkpt>
+			<trkpt lat="39.180808" lon="-109.002335">
+				<ele>1425.772</ele>
+			</trkpt>
+			<trkpt lat="39.181001" lon="-109.002421">
+				<ele>1425.772</ele>
+			</trkpt>
+			<trkpt lat="39.181516" lon="-109.002678">
+				<ele>1423.369</ele>
+			</trkpt>
+			<trkpt lat="39.181881" lon="-109.003043">
+				<ele>1422.889</ele>
+			</trkpt>
+			<trkpt lat="39.181945" lon="-109.003515">
+				<ele>1420.966</ele>
+			</trkpt>
+			<trkpt lat="39.181902" lon="-109.004202">
+				<ele>1420.005</ele>
+			</trkpt>
+			<trkpt lat="39.181688" lon="-109.005189">
+				<ele>1416.64</ele>
+			</trkpt>
+			<trkpt lat="39.181623" lon="-109.005618">
+				<ele>1417.121</ele>
+			</trkpt>
+			<trkpt lat="39.181881" lon="-109.006648">
+				<ele>1416.64</ele>
+			</trkpt>
+			<trkpt lat="39.182224" lon="-109.007592">
+				<ele>1413.275</ele>
+			</trkpt>
+			<trkpt lat="39.182482" lon="-109.008279">
+				<ele>1413.275</ele>
+			</trkpt>
+			<trkpt lat="39.182739" lon="-109.008536">
+				<ele>1409.43</ele>
+			</trkpt>
+			<trkpt lat="39.183125" lon="-109.008794">
+				<ele>1408.469</ele>
+			</trkpt>
+			<trkpt lat="39.183190" lon="-109.009137">
+				<ele>1409.43</ele>
+			</trkpt>
+			<trkpt lat="39.182954" lon="-109.009953">
+				<ele>1409.43</ele>
+			</trkpt>
+			<trkpt lat="39.183147" lon="-109.010081">
+				<ele>1409.43</ele>
+			</trkpt>
+			<trkpt lat="39.183533" lon="-109.010210">
+				<ele>1412.314</ele>
+			</trkpt>
+			<trkpt lat="39.183555" lon="-109.009995">
+				<ele>1412.314</ele>
+			</trkpt>
+			<trkpt lat="39.183662" lon="-109.009867">
+				<ele>1411.353</ele>
+			</trkpt>
+			<trkpt lat="39.183683" lon="-109.009888">
+				<ele>1411.833</ele>
+			</trkpt>
+			<trkpt lat="39.183640" lon="-109.010146">
+				<ele>1412.795</ele>
+			</trkpt>
+			<trkpt lat="39.183726" lon="-109.010231">
+				<ele>1413.756</ele>
+			</trkpt>
+			<trkpt lat="39.183941" lon="-109.010210">
+				<ele>1414.717</ele>
+			</trkpt>
+			<trkpt lat="39.184821" lon="-109.009330">
+				<ele>1418.562</ele>
+			</trkpt>
+			<trkpt lat="39.185207" lon="-109.009094">
+				<ele>1420.005</ele>
+			</trkpt>
+			<trkpt lat="39.185593" lon="-109.009008">
+				<ele>1420.966</ele>
+			</trkpt>
+			<trkpt lat="39.185979" lon="-109.008815">
+				<ele>1420.005</ele>
+			</trkpt>
+			<trkpt lat="39.187181" lon="-109.008451">
+				<ele>1420.005</ele>
+			</trkpt>
+			<trkpt lat="39.187181" lon="-109.008536">
+				<ele>1421.447</ele>
+			</trkpt>
+			<trkpt lat="39.187353" lon="-109.008343">
+				<ele>1420.966</ele>
+			</trkpt>
+			<trkpt lat="39.187868" lon="-109.008129">
+				<ele>1421.447</ele>
+			</trkpt>
+			<trkpt lat="39.188468" lon="-109.007978">
+				<ele>1424.811</ele>
+			</trkpt>
+			<trkpt lat="39.188747" lon="-109.008000">
+				<ele>1426.253</ele>
+			</trkpt>
+			<trkpt lat="39.188683" lon="-109.008687">
+				<ele>1428.176</ele>
+			</trkpt>
+			<trkpt lat="39.188533" lon="-109.009759">
+				<ele>1424.811</ele>
+			</trkpt>
+			<trkpt lat="39.188018" lon="-109.010983">
+				<ele>1423.85</ele>
+			</trkpt>
+			<trkpt lat="39.187031" lon="-109.012635">
+				<ele>1420.485</ele>
+			</trkpt>
+			<trkpt lat="39.186172" lon="-109.013815">
+				<ele>1418.562</ele>
+			</trkpt>
+			<trkpt lat="39.185464" lon="-109.014995">
+				<ele>1416.64</ele>
+			</trkpt>
+			<trkpt lat="39.185014" lon="-109.016004">
+				<ele>1414.717</ele>
+			</trkpt>
+			<trkpt lat="39.184971" lon="-109.016604">
+				<ele>1414.717</ele>
+			</trkpt>
+			<trkpt lat="39.185057" lon="-109.016583">
+				<ele>1415.198</ele>
+			</trkpt>
+			<trkpt lat="39.185228" lon="-109.016540">
+				<ele>1413.756</ele>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>

--- a/tests/gpx_files/one_track.gpx
+++ b/tests/gpx_files/one_track.gpx
@@ -9,6 +9,8 @@
 	<extensions/>
 	<trk>
 		<name><![CDATA[ACTIVE LOG]]></name>
+		<cmt><![CDATA[Comment Log]]></cmt>
+		<desc><![CDATA[Description Log]]></desc>
 		<trkseg>
 			<trkpt lat="38.782575" lon="-109.595146">
 				<time>2006-04-08T18:25:33Z</time>

--- a/tests/segment_test.rb
+++ b/tests/segment_test.rb
@@ -5,6 +5,7 @@ require 'gpx'
 
 class SegmentTest < Minitest::Test
    ONE_SEGMENT = File.join(File.dirname(__FILE__), "gpx_files/one_segment.gpx")
+   ONE_SEGMENT_NO_TIME = File.join(File.dirname(__FILE__), "gpx_files/one_segment_no_time.gpx")
 
    def setup
       @gpx_file = GPX::GPXFile.new(:gpx_file => ONE_SEGMENT)
@@ -19,6 +20,16 @@ class SegmentTest < Minitest::Test
       assert_equal(1480.087, @segment.highest_point.elevation)
       assert_in_delta(6.98803359528853, @segment.distance, 0.001)
       assert_equal(4466.0, @segment.duration)
+   end
+
+   def test_segment_read_no_time
+      gpx_file_no_time = GPX::GPXFile.new(:gpx_file => ONE_SEGMENT_NO_TIME)
+      segment_no_time = gpx_file_no_time.tracks.first.segments.first
+      assert_equal(189, segment_no_time.points.size)
+      assert_equal(1334.447, segment_no_time.lowest_point.elevation)
+      assert_equal(1480.087, segment_no_time.highest_point.elevation)
+      assert_in_delta(6.98803359528853, segment_no_time.distance, 0.001)
+      assert_equal(0, segment_no_time.duration)
    end
 
    def test_segment_crop

--- a/tests/segment_test.rb
+++ b/tests/segment_test.rb
@@ -26,6 +26,8 @@ class SegmentTest < Minitest::Test
       gpx_file_no_time = GPX::GPXFile.new(:gpx_file => ONE_SEGMENT_NO_TIME)
       segment_no_time = gpx_file_no_time.tracks.first.segments.first
       assert_equal(189, segment_no_time.points.size)
+      assert_equal(1334.447, segment_no_time.earliest_point.elevation)
+      assert_equal(1413.756, segment_no_time.latest_point.elevation)
       assert_equal(1334.447, segment_no_time.lowest_point.elevation)
       assert_equal(1480.087, segment_no_time.highest_point.elevation)
       assert_in_delta(6.98803359528853, segment_no_time.distance, 0.001)

--- a/tests/segment_test.rb
+++ b/tests/segment_test.rb
@@ -18,6 +18,7 @@ class SegmentTest < Minitest::Test
       assert_equal(1334.447, @segment.lowest_point.elevation)
       assert_equal(1480.087, @segment.highest_point.elevation)
       assert_in_delta(6.98803359528853, @segment.distance, 0.001)
+      assert_equal(4466.0, @segment.duration)
    end
 
    def test_segment_crop
@@ -37,6 +38,7 @@ class SegmentTest < Minitest::Test
       assert_equal(-109.009995, @segment.bounds.min_lon)
       assert_equal(39.187868,   @segment.bounds.max_lat)
       assert_equal(-108.999546, @segment.bounds.max_lon)
+      assert_equal(2711.0, @segment.duration)
    end
 
    def test_segment_delete
@@ -55,6 +57,7 @@ class SegmentTest < Minitest::Test
       assert_equal(-109.016604, @segment.bounds.min_lon)
       assert_equal(39.188747,   @segment.bounds.max_lat)
       assert_equal(-109.007978, @segment.bounds.max_lon)
+      assert_equal(4466.0, @segment.duration)
    end
 
    def test_segment_smooth
@@ -65,6 +68,7 @@ class SegmentTest < Minitest::Test
       assert_equal(1342.58, @segment.lowest_point.elevation)
       assert_equal(1479.09, @segment.highest_point.elevation)
       assert_in_delta(6.458085658, @segment.distance, 0.001)
+      assert_equal(4466.0, @segment.duration)
    end
 
    def test_segment_smooth_offset
@@ -75,6 +79,7 @@ class SegmentTest < Minitest::Test
       assert_equal(1334.447, @segment.lowest_point.elevation)
       assert_equal(1480.087, @segment.highest_point.elevation)
       assert_in_delta(6.900813095, @segment.distance, 0.001)
+      assert_equal(4466.0, @segment.duration)
    end
 
    def test_segment_smooth_absolute
@@ -85,6 +90,7 @@ class SegmentTest < Minitest::Test
       assert_equal(1334.447, @segment.lowest_point.elevation)
       assert_equal(1480.087, @segment.highest_point.elevation)
       assert_in_delta(6.900813095, @segment.distance, 0.001)
+      assert_equal(4466.0, @segment.duration)
    end
 
 end

--- a/tests/track_point_test.rb
+++ b/tests/track_point_test.rb
@@ -15,7 +15,7 @@ class TrackPointTest < Minitest::Test
 
   def test_haversine_distance_from
     distance = @point1.haversine_distance_from(@point2)
-    assert_equal(0.00197862991592239, distance)
+    assert_in_delta(0.00197862991592239, distance, 1e-18)
   end
 
   def test_pythagorean_distance_from

--- a/tests/track_test.rb
+++ b/tests/track_test.rb
@@ -20,6 +20,7 @@ class TrackTest < Minitest::Test
       assert_equal(-109.606948, @track.bounds.min_lon)
       assert_equal(38.791759, @track.bounds.max_lat)
       assert_equal(-109.447045, @track.bounds.max_lon)
+      assert_equal(3036.0,  @track.moving_duration)
    end
 
    def test_track_crop
@@ -39,6 +40,7 @@ class TrackTest < Minitest::Test
       assert_equal(-109.599781, @track.bounds.min_lon)
       assert_equal(38.789527, @track.bounds.max_lat)
       assert_equal(-109.594996, @track.bounds.max_lon)
+      assert_equal(1773.0,  @track.moving_duration)
    end
 
    def test_track_delete
@@ -49,17 +51,18 @@ class TrackTest < Minitest::Test
          :max_lon => -109.450000)
       @track.delete_area(area)
 
+      assert_equal(1229.0,  @track.moving_duration)
       #puts @track
-      #assert_equal("ACTIVE LOG", @track.name)
-      #assert_equal( 111, @track.points.size)
-      #assert_equal(4, @track.segments.size)
-      #assert_equal("1.62136024923607", @track.distance.to_s)
-      #assert_equal(1557.954, @track.lowest_point.elevation)
-      #assert_equal(1582.468, @track.highest_point.elevation)
-      #assert_equal(38.782511, @track.bounds.min_lat)
-      #assert_equal(-109.599781, @track.bounds.min_lon)
-      #assert_equal(38.789527, @track.bounds.max_lat)
-      #assert_equal(-109.594996, @track.bounds.max_lon)
+      assert_equal("ACTIVE LOG", @track.name)
+      assert_equal(71, @track.points.size)
+      assert_equal(6, @track.segments.size)
+      assert_in_delta(1.197905851972874, @track.distance, 0.00000000001)
+      assert_equal(1267.155, @track.lowest_point.elevation)
+      assert_equal(1594.003, @track.highest_point.elevation)
+      assert_equal(38.681488, @track.bounds.min_lat)
+      assert_equal(-109.606948, @track.bounds.min_lon)
+      assert_equal(38.791759, @track.bounds.max_lat)
+      assert_equal(-109.447045, @track.bounds.max_lon)
    end
 
 end

--- a/tests/track_test.rb
+++ b/tests/track_test.rb
@@ -11,6 +11,8 @@ class TrackTest < Minitest::Test
 
    def test_track_read
       assert_equal("ACTIVE LOG", @track.name)
+      assert_equal("Comment Log", @track.comment)
+      assert_equal("Description Log", @track.description)
       assert_equal( 182, @track.points.size)
       assert_equal(8, @track.segments.size)
       assert_in_delta(3.07249668492626, @track.distance, 0.001)
@@ -31,6 +33,8 @@ class TrackTest < Minitest::Test
          :max_lon => -109.450000)
       @track.crop(area)
       assert_equal("ACTIVE LOG", @track.name)
+      assert_equal("Comment Log", @track.comment)
+      assert_equal("Description Log", @track.description)
       assert_equal( 111, @track.points.size)
       assert_equal(4, @track.segments.size)
       assert_in_delta(1.62136024923607, @track.distance, 0.001)


### PR DESCRIPTION
Included in this PR:

- The calculation of average speed now relies on the moving_duration (duration of all tracks without pause between segments). This fix the issue #10
- Fix a broken test on Windows (very small diff on float value).
- Add the management of track comment and description.
- Ensure earliest_point and latest_point of segment are set enven if gpx file contains no time information

Test added for all cases.