### PR TITLE
Release 0.9.0, which updates a dep on Nokogiri, which updates a dep on Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.9.0] - 2017-01-05
+
+  * Upgrade Nokogiri deps to be more explicit, then explicitly bump the Ruby
+    dependency.
+
 ## [0.8.3] - 2017-01-05
 
   * Make Track comment and description fields be `attr_accessible` (#17 via

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [<img src="https://travis-ci.org/dougfales/gpx.svg" alt="Build Status" />](https://travis-ci.org/dougfales/gpx)
 [![Code Climate](https://codeclimate.com/github/dougfales/gpx/badges/gpa.svg)](https://codeclimate.com/github/dougfales/gpx)
 
-Copyright (C) 2006 Doug Fales doug@falesafeconsulting.com 
+Copyright (C) 2006 Doug Fales doug@falesafeconsulting.com
 
 Released under the MIT License.
 
@@ -19,9 +19,14 @@ rectangular areas within a file, and it also calculates some meta-data about
 the tracks and points in a file (such as distance, duration, average speed,
 etc).
 
+## Requirements
+
+As of `0.9.0`, `gpx` requires at least Ruby 2.1 to run.
+
 ## Examples
 
 Reading a GPX file, and cropping its contents to a given area:
+
 ```ruby
 gpx =  GPX::GPXFile.new(:gpx_file => filename)   # Read GPX file
 bounds = GPX::Bounds.new(params)                 # Create a rectangular area to crop

--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 [<img src="https://travis-ci.org/dougfales/gpx.svg" alt="Build Status" />](https://travis-ci.org/dougfales/gpx)
 [![Code Climate](https://codeclimate.com/github/dougfales/gpx/badges/gpa.svg)](https://codeclimate.com/github/dougfales/gpx)
 
-Copyright (C) 2006 Doug Fales doug@falesafeconsulting.com
-
-Released under the MIT License.
-
 ## What It Does
 
 This library reads GPX files and provides an API for reading and manipulating
@@ -46,28 +42,28 @@ Exporting an ActiveRecord to GPXFile (as Waypoints)
 #
 # Our active record in this example is called stop
 #
- 
-# models/stop.rb 
+
+# models/stop.rb
 class Stop < ActiveRecord::Base
    # This model has the following attributes:
    # name
    # lat
    # lon
    # updated_at
-   
+
    def self.to_gpx
      require 'GPX'
      gpx = GPX::GPXFile.new
      all.each do |stop|
        gpx.waypoints << GPX::Waypoint.new({name: stop.name, lat: stop.lat, lon: stop.lon, time: stop.updated_at})
-     end 
+     end
      gpx.to_s
    end
  end # class
 
 
 # controllers/stops.rb
-def index 
+def index
    @stops = Stop.all
    respond_to do |format|
     format.html {render :index}
@@ -78,8 +74,8 @@ end
 
 # Add this line to config/initializers/mime_types.rb
 Mime::Type.register "application/gpx+xml", :gpx
-  
- 
+
+
 # To get the xml file:
 #   http://localhost:3000/stops.gpx
 ```
@@ -93,13 +89,17 @@ This library was written to bridge the gap between my Garmin Geko
 and my website, WalkingBoss.org (RIP).  For that reason, it has always been more of a
 work-in-progress than an attempt at full GPX compliance.  The track side of the
 library has seen much more use than the route/waypoint side, so if you're doing
-something with routes or waypoints, you may need to tweak some things.  
+something with routes or waypoints, you may need to tweak some things.
 
 Since this code uses XML to read an entire GPX file into memory, it is not
 the fastest possible solution for working with GPX data, especially if you are
-working with tracks from several days or weeks.  
+working with tracks from several days or weeks.
 
 Finally, it should be noted that none of the distance/speed calculation or
 crop/delete code has been tested under International Date Line-crossing
 conditions.  That particular part of the code will likely be unreliable if
 you're zig-zagging across 180 degrees longitude routinely.
+
+## License
+
+MIT

--- a/gpx.gemspec
+++ b/gpx.gemspec
@@ -11,6 +11,8 @@ Gem::Specification.new do |s|
   s.summary = %q{A basic API for reading and writing GPX files.}
   s.description = %q{A basic API for reading and writing GPX files.}
 
+  s.required_ruby_version = '~>2.1'
+
   s.files = `git ls-files`.split($/)
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
@@ -18,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.homepage = "http://www.github.com/dougfales/gpx"
   s.add_dependency 'rake'
-  s.add_dependency 'nokogiri'
+  s.add_dependency 'nokogiri', '~>1.7'
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'minitest'
 end

--- a/lib/gpx/version.rb
+++ b/lib/gpx/version.rb
@@ -1,3 +1,3 @@
 module GPX
-  VERSION = "0.8.3"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
If Nokogiri, a core dependency of this app, requires Ruby 2.1+, we must follow suit.