### PR TITLE
Fix duplication of points on appending segment to track

### DIFF
--- a/lib/gpx/track.rb
+++ b/lib/gpx/track.rb
@@ -55,7 +55,6 @@ module GPX
     def append_segment(seg)
       update_meta_data(seg)
       @segments << seg
-      @points.concat(seg.points) unless seg.nil?
     end
 
     # Returns true if the given time occurs within any of the segments of this track.
@@ -125,7 +124,7 @@ module GPX
         @distance += seg.distance
       end
     end
- 
+
     protected
 
     def update_meta_data(seg)

--- a/tests/track_test.rb
+++ b/tests/track_test.rb
@@ -69,4 +69,13 @@ class TrackTest < Minitest::Test
       assert_equal(-109.447045, @track.bounds.max_lon)
    end
 
+   def test_append_segment
+     trk = GPX::Track.new
+     seg = GPX::Segment.new(track: trk)
+     pt = GPX::TrackPoint.new(lat: -118, lon: 34)
+     seg.append_point(pt)
+     trk.append_segment(seg)
+     assert_equal(1, trk.points.size)
+   end
+
 end


### PR DESCRIPTION
Was working on a Geojson conversion module and noticed this bug.  Points were already added to the track in the 'update_meta_data' method.