### PR TITLE
add new method extension_h for points

### DIFF
--- a/lib/gpx/bounds.rb
+++ b/lib/gpx/bounds.rb
@@ -22,7 +22,7 @@
 #++
 module GPX
   class Bounds < Base
-    attr_accessor :min_lat, :max_lat, :max_lon, :min_lon, :center_lat, :center_lon
+    attr_accessor :min_lat, :max_lat, :max_lon, :min_lon
 
     # Creates a new bounds object with the passed-in min and max longitudes
     # and latitudes.

--- a/lib/gpx/gpx_file.rb
+++ b/lib/gpx/gpx_file.rb
@@ -93,7 +93,7 @@ module GPX
       else
         reset_meta_data
         opts.each { |attr_name, value| instance_variable_set("@#{attr_name.to_s}", value) }
-        unless(@tracks.nil? or @tracks.size.zero?)
+        unless(!defined?(@tracks) or @tracks.nil? or @tracks.size.zero?)
           @tracks.each { |trk| update_meta_data(trk) }
           calculate_duration
         end

--- a/lib/gpx/point.rb
+++ b/lib/gpx/point.rb
@@ -24,7 +24,7 @@ module GPX
   # The base class for all points.  Trackpoint and Waypoint both descend from this base class.
   class Point < Base
     D_TO_R = Math::PI/180.0;
-    attr_accessor :lat, :lon, :time, :elevation, :gpx_file, :speed, :extensions_h
+    attr_accessor :lat, :lon, :time, :elevation, :gpx_file, :speed, :extensions, :extensions_h
 
     # When you need to manipulate individual points, you can create a Point
     # object with a latitude, a longitude, an elevation, and a time.  In

--- a/lib/gpx/point.rb
+++ b/lib/gpx/point.rb
@@ -24,7 +24,8 @@ module GPX
   # The base class for all points.  Trackpoint and Waypoint both descend from this base class.
   class Point < Base
     D_TO_R = Math::PI/180.0;
-    attr_accessor :lat, :lon, :time, :elevation, :gpx_file, :speed, :extensions, :extensions_h
+    attr_reader :lat, :lon
+    attr_accessor  :time, :elevation, :gpx_file, :speed, :extensions, :extensions_h
 
     # When you need to manipulate individual points, you can create a Point
     # object with a latitude, a longitude, an elevation, and a time.  In
@@ -92,7 +93,13 @@ module GPX
       e = {}
       element.children.each do |c|
         if c.class == Nokogiri::XML::Element
-          e[c.name] = c.text
+          if c.name ==  'WaypointExtension' and c.namespace.prefix == 'wptx1' # garmin nested extension
+            c.children.each do |gc|
+              e[gc.name] = gc.text
+            end
+          else
+            e[c.name] = c.text
+          end
         end
       end
       return e

--- a/lib/gpx/point.rb
+++ b/lib/gpx/point.rb
@@ -24,7 +24,7 @@ module GPX
   # The base class for all points.  Trackpoint and Waypoint both descend from this base class.
   class Point < Base
     D_TO_R = Math::PI/180.0;
-    attr_accessor :lat, :lon, :time, :elevation, :gpx_file, :speed, :extensions
+    attr_accessor :lat, :lon, :time, :elevation, :gpx_file, :speed, :extensions_h
 
     # When you need to manipulate individual points, you can create a Point
     # object with a latitude, a longitude, an elevation, and a time.  In
@@ -40,7 +40,7 @@ module GPX
         @time = (Time.xmlschema(elem.at("time").inner_text) rescue nil)
         @elevation = elem.at("ele").inner_text.to_f unless elem.at("ele").nil?
         @speed = elem.at("speed").inner_text.to_f unless elem.at("speed").nil?
-        @extensions = elem.at("extensions") unless elem.at("extensions").nil?
+        @extensions_h = wp_extensions(elem.at("extensions")) unless elem.at("extensions").nil?
       else
         @lat = opts[:lat]
         @lon = opts[:lon]
@@ -51,7 +51,6 @@ module GPX
       end
 
     end
-
 
     # Returns the latitude and longitude (in that order), separated by the
     # given delimeter.  This is useful for passing a point into another API
@@ -87,6 +86,16 @@ module GPX
     def lon=(longitude)
       @lonr = (longitude * D_TO_R)
       @lon = longitude
+    end
+
+    def wp_extensions( element )
+      e = {}
+      element.children.each do |c|
+        if c.class == Nokogiri::XML::Element
+          e[c.name] = c.text
+        end
+      end
+      return e
     end
   end
 end

--- a/lib/gpx/segment.rb
+++ b/lib/gpx/segment.rb
@@ -45,7 +45,7 @@ module GPX
       @bounds = Bounds.new
       if(opts[:element])
         segment_element = opts[:element]
-        last_pt = nil
+        #last_pt = nil
         if segment_element.is_a?(Nokogiri::XML::Node)
           segment_element.search("trkpt").each do |trkpt|
             pt = TrackPoint.new(:element => trkpt, :segment => self, :gpx_file => @gpx_file)
@@ -189,7 +189,7 @@ module GPX
         tmp_point.lat = ((lat_av) / n).round(7)
         tmp_points.push tmp_point
       end
-      last_pt = nil
+      #last_pt = nil
       @points.clear
       reset_meta_data
       #now commit the averages back and recalculate the distances


### PR DESCRIPTION
I have added a new method which parses the extensions into a hash indexed by extension child name.  It seems to work fine with QGIS ORG extensions.

For the curious I am exporting layers out of QGIS and the the feature attributes get put into the extensions.  I then have a ruby script that processes that and takes the items out of the extensions and puts them in the right component for my GPS.   E.g.  takes 'description' and maps it to 'cmt'.