### PR TITLE
Fix ArgumentError: comparison of Time with nil failed

### DIFF
--- a/lib/gpx/segment.rb
+++ b/lib/gpx/segment.rb
@@ -59,8 +59,8 @@ module GPX
     def append_point(pt)
       last_pt = @points[-1]
       if pt.time
-        @earliest_point = pt if(@earliest_point.nil? or pt.time < @earliest_point.time)
-        @latest_point   = pt if(@latest_point.nil? or pt.time > @latest_point.time)
+        @earliest_point = pt if(@earliest_point.nil? or (!@earliest_point.time.nil? and pt.time < @earliest_point.time))
+        @latest_point   = pt if(@latest_point.nil? or (!@latest_point.time.nil? and pt.time > @latest_point.time))
       else
         # when no time information in data, we consider the points are ordered
         @earliest_point = @points[0]
@@ -152,7 +152,7 @@ module GPX
         raise Exception, "find_end_point_by_time_or_offset requires an argument of type Time or Integer"
       end
     end
-  
+
     # smooths the location data in the segment (by recalculating the location as an average of 20 neighbouring points.  Useful for removing noise from GPS traces.
     def smooth_location_by_average(opts={})
       seconds_either_side = opts[:averaging_window] || 20
@@ -166,13 +166,13 @@ module GPX
       @points.each do |point|
         if point.time > latest || point.time < earliest
           tmp_points.push point #add the point unaltered
-          next 
+          next
         end
         lat_av = 0.to_f
         lon_av = 0.to_f
         alt_av = 0.to_f
         n = 0
-        # k ranges from the time of the current point +/- 20s 
+        # k ranges from the time of the current point +/- 20s
         (-1*seconds_either_side..seconds_either_side).each do |k|
           # find the point nearest to the time offset indicated by k
           contributing_point = closest_point(point.time + k)

--- a/tests/gpx_files/one_segment_mixed_times.gpx
+++ b/tests/gpx_files/one_segment_mixed_times.gpx
@@ -1,0 +1,884 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="MapSource 6.16.3" version="1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+
+  <metadata>
+    <link href="http://www.garmin.com">
+      <text>Garmin International</text>
+    </link>
+    <time>2017-03-14T17:27:23Z</time>
+    <bounds maxlat="52.157299993559718" maxlon="5.391189996153116" minlat="52.068071365356445" minlon="5.070178443565965"/>
+  </metadata>
+
+  <wpt lat="52.085494073107839" lon="5.14855032786727">
+    <time>2016-11-07T15:08:48Z</time>
+    <name>10_Erasmuslaan Nieuwe Bouwen Rietveld</name>
+    <cmt>Erasmuslaan 7
+Utrecht, Utrecht, NLD</cmt>
+    <desc>Erasmuslaan 7
+Utrecht, Utrecht, NLD</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+        <gpxx:Address>
+          <gpxx:StreetAddress>Erasmuslaan 7</gpxx:StreetAddress>
+          <gpxx:City>Utrecht</gpxx:City>
+          <gpxx:State>Utrecht</gpxx:State>
+          <gpxx:Country>NLD</gpxx:Country>
+        </gpxx:Address>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.083353083580732" lon="5.23567870259285">
+    <time>2016-11-08T07:29:22Z</time>
+    <name>11_muziekschool Rietveld</name>
+    <cmt>Gebouw</cmt>
+    <desc>Gebouw</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.109782984480262" lon="5.24183789268136">
+    <time>2016-11-07T15:42:07Z</time>
+    <name>12_villa's Van t Hoff</name>
+    <cmt>Woonhuis</cmt>
+    <desc>Woonhuis</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.128977878019214" lon="5.274442657828331">
+    <time>2016-11-07T15:59:51Z</time>
+    <name>13_Voormalig Vliegveld Soesterberg</name>
+    <cmt>Voormalig Vliegveld Soesterberg</cmt>
+    <desc>Voormalig Vliegveld Soesterberg</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.152302786707878" lon="5.384883368387818">
+    <time>2016-11-07T16:01:07Z</time>
+    <name>14_De Zonnehof</name>
+    <cmt>Zonnehof 16
+Amersfoort, Utrecht, NLD</cmt>
+    <desc>Zonnehof 16
+Amersfoort, Utrecht, NLD</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+        <gpxx:Address>
+          <gpxx:StreetAddress>Zonnehof 16</gpxx:StreetAddress>
+          <gpxx:City>Amersfoort</gpxx:City>
+          <gpxx:State>Utrecht</gpxx:State>
+          <gpxx:Country>NLD</gpxx:Country>
+        </gpxx:Address>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.154544442892075" lon="5.390010410919786">
+    <time>2016-11-07T16:01:31Z</time>
+    <name>15_Mondriaanhuis</name>
+    <cmt>Rozemarijnsteeg 6
+Amersfoort, Utrecht, NLD</cmt>
+    <desc>Rozemarijnsteeg 6
+Amersfoort, Utrecht, NLD</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+        <gpxx:Address>
+          <gpxx:StreetAddress>Rozemarijnsteeg 6</gpxx:StreetAddress>
+          <gpxx:City>Amersfoort</gpxx:City>
+          <gpxx:State>Utrecht</gpxx:State>
+          <gpxx:Country>NLD</gpxx:Country>
+        </gpxx:Address>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.127107121050358" lon="5.073764221742749">
+    <time>2016-11-08T07:24:30Z</time>
+    <name>1_slot zuilen</name>
+    <cmt>Toegangsweg</cmt>
+    <desc>Toegangsweg</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.083756923675537" lon="5.125916004180908">
+    <time>2016-11-07T15:05:22Z</time>
+    <name>2_Centraal Museum</name>
+    <cmt>Centraal Museum
+Agnietenstraat 1
+Utrecht, Utrecht, 3512XA, NLD
+</cmt>
+    <desc>Centraal Museum
+Agnietenstraat 1
+Utrecht, Utrecht, 3512XA, NLD
+</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+        <gpxx:Address>
+          <gpxx:StreetAddress>Agnietenstraat 1</gpxx:StreetAddress>
+          <gpxx:City>Utrecht</gpxx:City>
+          <gpxx:State>Utrecht</gpxx:State>
+          <gpxx:Country>NLD</gpxx:Country>
+          <gpxx:PostalCode>3512XA</gpxx:PostalCode>
+        </gpxx:Address>
+        <gpxx:PhoneNumber></gpxx:PhoneNumber>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.077693287283182" lon="5.129799507558346">
+    <time>2016-11-07T15:06:21Z</time>
+    <name>3_Graf Rietveld</name>
+    <cmt>Eerste Algemene Begraafplaats Soestbergen</cmt>
+    <desc>Eerste Algemene Begraafplaats Soestbergen</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.07825998775661" lon="5.13808929361403">
+    <time>2016-11-07T16:11:25Z</time>
+    <name>4_twee bungalows Rietveld + bankje</name>
+    <cmt>Bebouwde Kom</cmt>
+    <desc>Bebouwde Kom</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.081649210304022" lon="5.140653820708394">
+    <time>2016-11-07T16:11:03Z</time>
+    <name>5_Meubelmakerij Rietveld</name>
+    <cmt>Ferdinand Bolstraat 5
+Utrecht, Utrecht, NLD</cmt>
+    <desc>Ferdinand Bolstraat 5
+Utrecht, Utrecht, NLD</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+        <gpxx:Address>
+          <gpxx:StreetAddress>Ferdinand Bolstraat 5</gpxx:StreetAddress>
+          <gpxx:City>Utrecht</gpxx:City>
+          <gpxx:State>Utrecht</gpxx:State>
+          <gpxx:Country>NLD</gpxx:Country>
+        </gpxx:Address>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.084416076540947" lon="5.13938857242465">
+    <time>2016-11-07T16:49:59Z</time>
+    <name>6_chauffeurswoning Rietveld</name>
+    <cmt>Waldeck Pyrmontkade 16
+Utrecht, Utrecht, NLD</cmt>
+    <desc>Waldeck Pyrmontkade 16
+Utrecht, Utrecht, NLD</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+        <gpxx:Address>
+          <gpxx:StreetAddress>Waldeck Pyrmontkade 16</gpxx:StreetAddress>
+          <gpxx:City>Utrecht</gpxx:City>
+          <gpxx:State>Utrecht</gpxx:State>
+          <gpxx:Country>NLD</gpxx:Country>
+        </gpxx:Address>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.084654290229082" lon="5.138781974092126">
+    <time>2016-11-07T16:10:27Z</time>
+    <name>7_Julianalaan verbouwing Rietveld</name>
+    <cmt> Lf4</cmt>
+    <desc> Lf4</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.085323333740234" lon="5.14758825302124">
+    <time>2016-11-07T15:08:32Z</time>
+    <name>8_Rietveld-Schröderhuis</name>
+    <cmt>Rietveld-Schröderhuis
+
+Utrecht, Utrecht, NLD
+</cmt>
+    <desc>Rietveld-Schröderhuis
+
+Utrecht, Utrecht, NLD
+</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+        <gpxx:Address>
+          <gpxx:City>Utrecht</gpxx:City>
+          <gpxx:State>Utrecht</gpxx:State>
+          <gpxx:Country>NLD</gpxx:Country>
+        </gpxx:Address>
+        <gpxx:PhoneNumber></gpxx:PhoneNumber>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <wpt lat="52.085028206929564" lon="5.148036349564791">
+    <time>2016-11-07T15:30:41Z</time>
+    <name>9_kunstwerk Rietveld onder viaduct</name>
+    <cmt>Van Amersfoort naar Utrecht (fietsroute: 537552) - route.nl
+
+</cmt>
+    <desc>Van Amersfoort naar Utrecht (fietsroute: 537552) - route.nl
+
+</desc>
+    <sym>Flag</sym>
+    <extensions>
+      <gpxx:WaypointExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayMode>SymbolAndName</gpxx:DisplayMode>
+      </gpxx:WaypointExtension>
+    </extensions>
+  </wpt>
+
+  <trk>
+    <name>De Stijl_Van Amersfoort naar Utrecht_zomer 2017</name>
+    <extensions>
+      <gpxx:TrackExtension xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+        <gpxx:DisplayColor>Red</gpxx:DisplayColor>
+      </gpxx:TrackExtension>
+    </extensions>
+    <trkseg>
+      <trkpt lat="52.154679978266358" lon="5.390620026737452"/>
+      <trkpt lat="52.154570007696748" lon="5.390820018947125"/>
+      <trkpt lat="52.154370015487075" lon="5.391180021688342"/>
+      <trkpt lat="52.154370015487075" lon="5.391180021688342"/>
+      <trkpt lat="52.154370015487075" lon="5.391189996153116"/>
+      <trkpt lat="52.154279993847013" lon="5.390990003943443"/>
+      <trkpt lat="52.154249986633658" lon="5.391010036692023"/>
+      <trkpt lat="52.154249986633658" lon="5.391010036692023"/>
+      <trkpt lat="52.15405996888876" lon="5.391120007261634"/>
+      <trkpt lat="52.153929965570569" lon="5.391180021688342"/>
+      <trkpt lat="52.153929965570569" lon="5.391180021688342"/>
+      <trkpt lat="52.153929965570569" lon="5.391189996153116"/>
+      <trkpt lat="52.153859976679087" lon="5.390720022842288"/>
+      <trkpt lat="52.15375998057425" lon="5.389840006828308"/>
+      <trkpt lat="52.153729973360896" lon="5.389860039576888"/>
+      <trkpt lat="52.153729973360896" lon="5.389860039576888"/>
+      <trkpt lat="52.153399977833033" lon="5.390019966289401"/>
+      <trkpt lat="52.153139971196651" lon="5.390249965712428"/>
+      <trkpt lat="52.15289999730885" lon="5.390509972348809"/>
+      <trkpt lat="52.152869990095496" lon="5.390550037845969"/>
+      <trkpt lat="52.152720037847757" lon="5.390590019524097"/>
+      <trkpt lat="52.152560027316213" lon="5.390690015628934"/>
+      <trkpt lat="52.15249003842473" lon="5.390760004520416"/>
+      <trkpt lat="52.152539994567633" lon="5.391039960086346"/>
+      <trkpt lat="52.152579976245761" lon="5.391140040010214"/>
+      <trkpt lat="52.15276999399066" lon="5.390980029478669"/>
+      <trkpt lat="52.152820033952594" lon="5.390910040587187"/>
+      <trkpt lat="52.152760019525886" lon="5.390750030055642"/>
+      <trkpt lat="52.152739986777306" lon="5.390690015628934"/>
+      <trkpt lat="52.152739986777306" lon="5.390690015628934"/>
+      <trkpt lat="52.152460031211376" lon="5.389689970761538"/>
+      <trkpt lat="52.152400016784668" lon="5.389040037989616"/>
+      <trkpt lat="52.152430023998022" lon="5.387990036979318"/>
+      <trkpt lat="52.152630016207695" lon="5.38702997379005"/>
+      <trkpt lat="52.152709979563951" lon="5.386629989370704"/>
+      <trkpt lat="52.152709979563951" lon="5.386629989370704"/>
+      <trkpt lat="52.152709979563951" lon="5.386629989370704"/>
+      <trkpt lat="52.15289999730885" lon="5.385960023850203"/>
+      <trkpt lat="52.153109963983297" lon="5.385430036112666"/>
+      <trkpt lat="52.153390003368258" lon="5.384929971769452"/>
+      <trkpt lat="52.153680017217994" lon="5.384529987350106"/>
+      <trkpt lat="52.153989979997277" lon="5.384290013462305"/>
+      <trkpt lat="52.154360041022301" lon="5.384039981290698"/>
+      <trkpt lat="52.154769999906421" lon="5.383860021829605"/>
+      <trkpt lat="52.155680023133755" lon="5.383879970759153"/>
+      <trkpt lat="52.155840033665299" lon="5.383860021829605"/>
+      <trkpt lat="52.155799968168139" lon="5.383400022983551"/>
+      <trkpt lat="52.155940029770136" lon="5.383430030196905"/>
+      <trkpt lat="52.156019993126392" lon="5.383330034092069"/>
+      <trkpt lat="52.156349988654256" lon="5.383310001343489"/>
+      <trkpt lat="52.156579988077283" lon="5.383189972490072"/>
+      <trkpt lat="52.156760031357408" lon="5.383070027455688"/>
+      <trkpt lat="52.156930016353726" lon="5.382840028032661"/>
+      <trkpt lat="52.157279960811138" lon="5.382120022550225"/>
+      <trkpt lat="52.157290019094944" lon="5.382129997014999"/>
+      <trkpt lat="52.157299993559718" lon="5.382099989801645"/>
+      <trkpt lat="52.156909983605146" lon="5.381630016490817"/>
+      <trkpt lat="52.156319981440902" lon="5.381119977682829"/>
+      <trkpt lat="52.155750012025237" lon="5.380420004948974"/>
+      <trkpt lat="52.155250031501055" lon="5.379620036110282"/>
+      <trkpt lat="52.154719959944487" lon="5.378910005092621"/>
+      <trkpt lat="52.154300026595592" lon="5.378169966861606"/>
+      <trkpt lat="52.154259961098433" lon="5.37819997407496"/>
+      <trkpt lat="52.153729973360896" lon="5.378740020096302"/>
+      <trkpt lat="52.153699966147542" lon="5.378659972921014"/>
+      <trkpt lat="52.153610028326511" lon="5.378450006246567"/>
+      <trkpt lat="52.153190011158586" lon="5.37736002355814"/>
+      <trkpt lat="52.153009967878461" lon="5.376879991963506"/>
+      <trkpt lat="52.152960011735559" lon="5.376689974218607"/>
+      <trkpt lat="52.152939978986979" lon="5.376559970900416"/>
+      <trkpt lat="52.152939978986979" lon="5.376389985904098"/>
+      <trkpt lat="52.152960011735559" lon="5.376289989799261"/>
+      <trkpt lat="52.153039975091815" lon="5.376099972054362"/>
+      <trkpt lat="52.153030000627041" lon="5.37605001591146"/>
+      <trkpt lat="52.152779968455434" lon="5.376020008698106"/>
+      <trkpt lat="52.152669997885823" lon="5.375999975949526"/>
+      <trkpt lat="52.152720037847757" lon="5.373629992827773"/>
+      <trkpt lat="52.152649965137243" lon="5.373220033943653"/>
+      <trkpt lat="52.152609983459115" lon="5.372909987345338"/>
+      <trkpt lat="52.152579976245761" lon="5.372579991817474"/>
+      <trkpt lat="52.152530020102859" lon="5.368140013888478"/>
+      <trkpt lat="52.151473062112927" lon="5.368142277002335"/>
+      <trkpt lat="52.150821536779404" lon="5.367028154432774"/>
+      <trkpt lat="52.150673344731331" lon="5.365805653855205"/>
+      <trkpt lat="52.15094399638474" lon="5.364201860502362"/>
+      <trkpt lat="52.151637515053153" lon="5.363533152267337"/>
+      <trkpt lat="52.151303077116609" lon="5.362112335860729"/>
+      <trkpt lat="52.150258608162403" lon="5.360311064869165"/>
+      <trkpt lat="52.149910926818848" lon="5.359635315835476"/>
+      <trkpt lat="52.149466266855597" lon="5.358898546546698"/>
+      <trkpt lat="52.149695595726371" lon="5.35776749253273"/>
+      <trkpt lat="52.150308983400464" lon="5.356086669489741"/>
+      <trkpt lat="52.150354161858559" lon="5.355906207114458"/>
+      <trkpt lat="52.150715757161379" lon="5.355868153274059"/>
+      <trkpt lat="52.150769988074899" lon="5.355890030041337"/>
+      <trkpt lat="52.150920024141669" lon="5.355730019509792"/>
+      <trkpt lat="52.150980038568377" lon="5.35566003061831"/>
+      <trkpt lat="52.150679966434836" lon="5.354889985173941"/>
+      <trkpt lat="52.150539988651872" lon="5.354569964110851"/>
+      <trkpt lat="52.150539988651872" lon="5.354569964110851"/>
+      <trkpt lat="52.150409985333681" lon="5.354260001331568"/>
+      <trkpt lat="52.150339996442199" lon="5.354060009121895"/>
+      <trkpt lat="52.150339996442199" lon="5.353979961946607"/>
+      <trkpt lat="52.150360029190779" lon="5.353890024125576"/>
+      <trkpt lat="52.150490032508969" lon="5.353760020807385"/>
+      <trkpt lat="52.150660017505288" lon="5.353609984740615"/>
+      <trkpt lat="52.150799995288253" lon="5.353479981422424"/>
+      <trkpt lat="52.150957910344005" lon="5.353341596201062">
+        <time>2016-11-21T12:18:50Z</time>
+      </trkpt>
+      <trkpt lat="52.151190843433142" lon="5.352895259857178"/>
+      <trkpt lat="52.151263598352671" lon="5.352057404816151"/>
+      <trkpt lat="52.151437103748322" lon="5.349829159677029"/>
+      <trkpt lat="52.151624020189047" lon="5.34904251806438"/>
+      <trkpt lat="52.151865670457482" lon="5.348625602200627"/>
+      <trkpt lat="52.15218317694962" lon="5.348135763779283"/>
+      <trkpt lat="52.152268253266811" lon="5.347262201830745"/>
+      <trkpt lat="52.152268253266811" lon="5.346231227740645"/>
+      <trkpt lat="52.152167418971658" lon="5.344852488487959"/>
+      <trkpt lat="52.152290130034089" lon="5.344464825466275"/>
+      <trkpt lat="52.152676451951265" lon="5.343936765566468"/>
+      <trkpt lat="52.152935955673456" lon="5.343551784753799"/>
+      <trkpt lat="52.153092445805669" lon="5.342754917219281"/>
+      <trkpt lat="52.153092445805669" lon="5.342725496739149"/>
+      <trkpt lat="52.153123710304499" lon="5.341663928702474"/>
+      <trkpt lat="52.153105018660426" lon="5.338081168010831"/>
+      <trkpt lat="52.153004100546241" lon="5.33352367579937"/>
+      <trkpt lat="52.152836713939905" lon="5.333096450194717"/>
+      <trkpt lat="52.152674859389663" lon="5.332485157996416"/>
+      <trkpt lat="52.15247537009418" lon="5.329540511593223"/>
+      <trkpt lat="52.152294740080833" lon="5.329296262934804"/>
+      <trkpt lat="52.151468871161342" lon="5.329081350937486"/>
+      <trkpt lat="52.150894040241838" lon="5.327973766252399"/>
+      <trkpt lat="52.15083310380578" lon="5.327571015805006"/>
+      <trkpt lat="52.150880713015795" lon="5.326533000916243"/>
+      <trkpt lat="52.151030078530312" lon="5.325624821707606"/>
+      <trkpt lat="52.151305424049497" lon="5.324622010812163"/>
+      <trkpt lat="52.151305424049497" lon="5.324592590332031"/>
+      <trkpt lat="52.151216994971037" lon="5.324050281196833"/>
+      <trkpt lat="52.151047177612782" lon="5.323630766943097"/>
+      <trkpt lat="52.151493681594729" lon="5.322947641834617"/>
+      <trkpt lat="52.151812026277184" lon="5.32232872210443"/>
+      <trkpt lat="52.152220141142607" lon="5.322166280820966"/>
+      <trkpt lat="52.152510993182659" lon="5.322318496182561"/>
+      <trkpt lat="52.152802683413029" lon="5.322318496182561"/>
+      <trkpt lat="52.153231920674443" lon="5.32174676656723"/>
+      <trkpt lat="52.153589241206646" lon="5.321344016119838"/>
+      <trkpt lat="52.154094502329826" lon="5.321487262845039"/>
+      <trkpt lat="52.15435559861362" lon="5.321813402697444"/>
+      <trkpt lat="52.154752817004919" lon="5.32171105965972"/>
+      <trkpt lat="52.15490142814815" lon="5.321129020303488"/>
+      <trkpt lat="52.154834205284715" lon="5.320329889655113"/>
+      <trkpt lat="52.154821716248989" lon="5.320329889655113"/>
+      <trkpt lat="52.154895141720772" lon="5.319718429818749"/>
+      <trkpt lat="52.155336197465658" lon="5.319379465654492"/>
+      <trkpt lat="52.155692847445607" lon="5.318072224035859"/>
+      <trkpt lat="52.156003229320049" lon="5.317386668175459"/>
+      <trkpt lat="52.156003229320049" lon="5.317112999036908"/>
+      <trkpt lat="52.155805416405201" lon="5.316871264949441"/>
+      <trkpt lat="52.154997484758496" lon="5.31643389724195"/>
+      <trkpt lat="52.154903691262007" lon="5.31608990393579"/>
+      <trkpt lat="52.154736304655671" lon="5.315240733325481"/>
+      <trkpt lat="52.154733873903751" lon="5.314632039517164"/>
+      <trkpt lat="52.154921628534794" lon="5.313865849748254"/>
+      <trkpt lat="52.154895812273026" lon="5.313225137069821"/>
+      <trkpt lat="52.154889525845647" lon="5.311874309554696"/>
+      <trkpt lat="52.154908301308751" lon="5.31132822856307"/>
+      <trkpt lat="52.15494585223496" lon="5.310884574428201"/>
+      <trkpt lat="52.154851974919438" lon="5.310245119035244"/>
+      <trkpt lat="52.154470263049006" lon="5.308254919946194"/>
+      <trkpt lat="52.154194163158536" lon="5.307038202881813"/>
+      <trkpt lat="52.153954776003957" lon="5.305608920753002"/>
+      <trkpt lat="52.15393683873117" lon="5.305608920753002"/>
+      <trkpt lat="52.153860982507467" lon="5.304726054891944"/>
+      <trkpt lat="52.153860982507467" lon="5.303929271176457"/>
+      <trkpt lat="52.153929797932506" lon="5.30313634313643"/>
+      <trkpt lat="52.153966510668397" lon="5.302739879116416"/>
+      <trkpt lat="52.153843799605966" lon="5.302580120041966"/>
+      <trkpt lat="52.15279346331954" lon="5.302532762289047"/>
+      <trkpt lat="52.151892492547631" lon="5.302315251901746"/>
+      <trkpt lat="52.151274662464857" lon="5.302122216671705"/>
+      <trkpt lat="52.150906277820468" lon="5.30136751011014"/>
+      <trkpt lat="52.150499587878585" lon="5.3002177644521"/>
+      <trkpt lat="52.149814534932375" lon="5.299597419798374"/>
+      <trkpt lat="52.148629585281014" lon="5.299096098169684"/>
+      <trkpt lat="52.147952243685722" lon="5.299226436764002"/>
+      <trkpt lat="52.14717716909945" lon="5.299088386818767"/>
+      <trkpt lat="52.146086012944579" lon="5.298630315810442"/>
+      <trkpt lat="52.145692650228739" lon="5.298568876460195"/>
+      <trkpt lat="52.145518222823739" lon="5.298658311367035"/>
+      <trkpt lat="52.145350920036435" lon="5.299219815060496"/>
+      <trkpt lat="52.145350920036435" lon="5.299941077828407"/>
+      <trkpt lat="52.145240027457476" lon="5.30012003146112"/>
+      <trkpt lat="52.145319990813732" lon="5.30009999871254"/>
+      <trkpt lat="52.145210020244122" lon="5.299960020929575"/>
+      <trkpt lat="52.145210020244122" lon="5.299960020929575"/>
+      <trkpt lat="52.145040035247803" lon="5.299749970436096"/>
+      <trkpt lat="52.143459962680936" lon="5.297509990632534"/>
+      <trkpt lat="52.14222002774477" lon="5.295820031315088"/>
+      <trkpt lat="52.141939988359809" lon="5.295419963076711"/>
+      <trkpt lat="52.141709988936782" lon="5.295049985870719"/>
+      <trkpt lat="52.141440007835627" lon="5.294700041413307"/>
+      <trkpt lat="52.140450021252036" lon="5.293630007654429"/>
+      <trkpt lat="52.137630013749003" lon="5.290830032899976"/>
+      <trkpt lat="52.136949989944696" lon="5.290370034053922"/>
+      <trkpt lat="52.13500002399087" lon="5.289249960333109"/>
+      <trkpt lat="52.134359981864691" lon="5.288909990340471"/>
+      <trkpt lat="52.133499998599291" lon="5.288380002602935"/>
+      <trkpt lat="52.132970010861754" lon="5.28819995932281"/>
+      <trkpt lat="52.130730031058192" lon="5.287729986011982"/>
+      <trkpt lat="52.130319988355041" lon="5.287499986588955"/>
+      <trkpt lat="52.130059981718659" lon="5.28738004155457"/>
+      <trkpt lat="52.130059981718659" lon="5.287320027127862"/>
+      <trkpt lat="52.130059981718659" lon="5.287320027127862"/>
+      <trkpt lat="52.130059981718659" lon="5.28738004155457"/>
+      <trkpt lat="52.129610041156411" lon="5.286890035495162"/>
+      <trkpt lat="52.128510000184178" lon="5.285810027271509"/>
+      <trkpt lat="52.128410004079342" lon="5.285529987886548"/>
+      <trkpt lat="52.128430036827922" lon="5.282409992069006"/>
+      <trkpt lat="52.127209967002273" lon="5.282400017604232"/>
+      <trkpt lat="52.12704760953784" lon="5.282322317361832"/>
+      <trkpt lat="52.126306565478444" lon="5.282322317361832"/>
+      <trkpt lat="52.125754030421376" lon="5.282520717009902"/>
+      <trkpt lat="52.125740619376302" lon="5.282498672604561"/>
+      <trkpt lat="52.12543074041605" lon="5.282652899622917"/>
+      <trkpt lat="52.125215157866478" lon="5.282520717009902"/>
+      <trkpt lat="52.123436518013477" lon="5.283666690811515"/>
+      <trkpt lat="52.123288325965405" lon="5.284129455685616"/>
+      <trkpt lat="52.123072659596801" lon="5.284327855333686"/>
+      <trkpt lat="52.12304575368762" lon="5.284305810928345"/>
+      <trkpt lat="52.122668651863933" lon="5.284239677712321"/>
+      <trkpt lat="52.121186396107078" lon="5.285165291279554"/>
+      <trkpt lat="52.121172901242971" lon="5.285165291279554"/>
+      <trkpt lat="52.120970813557506" lon="5.285099158063531"/>
+      <trkpt lat="52.119771698489785" lon="5.280471425503492"/>
+      <trkpt lat="52.119003664702177" lon="5.277738673612475"/>
+      <trkpt lat="52.119192257523537" lon="5.277474224567413"/>
+      <trkpt lat="52.119165351614356" lon="5.277474224567413"/>
+      <trkpt lat="52.119515715166926" lon="5.27740809135139"/>
+      <trkpt lat="52.119717802852392" lon="5.277275824919343"/>
+      <trkpt lat="52.119839088991284" lon="5.277099553495646"/>
+      <trkpt lat="52.119825594127178" lon="5.276879109442234"/>
+      <trkpt lat="52.119812099263072" lon="5.276879109442234"/>
+      <trkpt lat="52.117265593260527" lon="5.270367041230202"/>
+      <trkpt lat="52.11572952568531" lon="5.265077808871865"/>
+      <trkpt lat="52.115506650879979" lon="5.264180358499289"/>
+      <trkpt lat="52.114231009036303" lon="5.25936646386981"/>
+      <trkpt lat="52.112451363354921" lon="5.253056902438402"/>
+      <trkpt lat="52.11045135743916" lon="5.246217101812363"/>
+      <trkpt lat="52.108423355966806" lon="5.238875476643443"/>
+      <trkpt lat="52.108057653531432" lon="5.23710161447525"/>
+      <trkpt lat="52.10803996771574" lon="5.236570034176111"/>
+      <trkpt lat="52.108000321313739" lon="5.237063644453883">
+        <time>2016-11-08T13:34:19Z</time>
+      </trkpt>
+      <trkpt lat="52.107532024383545" lon="5.236916542053223"/>
+      <trkpt lat="52.107338905334473" lon="5.236916542053223"/>
+      <trkpt lat="52.107124328613281" lon="5.237023830413818"/>
+      <trkpt lat="52.107017040252686" lon="5.237088203430176"/>
+      <trkpt lat="52.106502056121826" lon="5.237452983856201"/>
+      <trkpt lat="52.105751037597656" lon="5.238075256347656"/>
+      <trkpt lat="52.104334831237793" lon="5.239062309265137"/>
+      <trkpt lat="52.103798389434814" lon="5.239448547363281"/>
+      <trkpt lat="52.103734016418457" lon="5.23949146270752"/>
+      <trkpt lat="52.103047370910645" lon="5.240006446838379"/>
+      <trkpt lat="52.103004455566406" lon="5.240092277526856"/>
+      <trkpt lat="52.102982997894287" lon="5.240199565887451"/>
+      <trkpt lat="52.102875709533691" lon="5.240285396575928"/>
+      <trkpt lat="52.102768421173096" lon="5.240285396575928"/>
+      <trkpt lat="52.102725505828857" lon="5.24024248123169"/>
+      <trkpt lat="52.102682590484619" lon="5.240178108215332"/>
+      <trkpt lat="52.102596759796143" lon="5.239877700805664"/>
+      <trkpt lat="52.102553844451904" lon="5.239920616149902"/>
+      <trkpt lat="52.102317810058594" lon="5.240113735198975"/>
+      <trkpt lat="52.102017402648926" lon="5.240414142608643"/>
+      <trkpt lat="52.101545333862305" lon="5.240778923034668"/>
+      <trkpt lat="52.101309299468994" lon="5.240950584411621"/>
+      <trkpt lat="52.101116180419922" lon="5.241057872772217"/>
+      <trkpt lat="52.100493907928467" lon="5.2414870262146"/>
+      <trkpt lat="52.099742889404297" lon="5.242002010345459"/>
+      <trkpt lat="52.099592685699463" lon="5.242087841033936"/>
+      <trkpt lat="52.099485397338867" lon="5.242173671722412"/>
+      <trkpt lat="52.099142074584961" lon="5.242388248443604"/>
+      <trkpt lat="52.098884582519531" lon="5.242581367492676"/>
+      <trkpt lat="52.098498344421387" lon="5.242860317230225"/>
+      <trkpt lat="52.098391056060791" lon="5.242881774902344"/>
+      <trkpt lat="52.0981764793396" lon="5.24298906326294"/>
+      <trkpt lat="52.098090648651123" lon="5.243139266967773"/>
+      <trkpt lat="52.097382545471191" lon="5.243632793426514"/>
+      <trkpt lat="52.097253799438477" lon="5.24371862411499"/>
+      <trkpt lat="52.096974849700928" lon="5.243761539459229"/>
+      <trkpt lat="52.096438407897949" lon="5.243654251098633"/>
+      <trkpt lat="52.095794677734375" lon="5.243461132049561"/>
+      <trkpt lat="52.095751762390137" lon="5.243525505065918"/>
+      <trkpt lat="52.095687389373779" lon="5.243632793426514"/>
+      <trkpt lat="52.095773220062256" lon="5.243761539459229"/>
+      <trkpt lat="52.095944881439209" lon="5.243782997131348"/>
+      <trkpt lat="52.096095085144043" lon="5.243761539459229"/>
+      <trkpt lat="52.096266746520996" lon="5.243847370147705"/>
+      <trkpt lat="52.096395492553711" lon="5.243847370147705"/>
+      <trkpt lat="52.096974849700928" lon="5.244040489196777"/>
+      <trkpt lat="52.097125053405762" lon="5.244061946868897"/>
+      <trkpt lat="52.097296714782715" lon="5.243997573852539"/>
+      <trkpt lat="52.09742546081543" lon="5.243868827819824"/>
+      <trkpt lat="52.097404003143311" lon="5.243740081787109"/>
+      <trkpt lat="52.097382545471191" lon="5.243632793426514"/>
+      <trkpt lat="52.097253799438477" lon="5.24371862411499"/>
+      <trkpt lat="52.096974849700928" lon="5.243761539459229"/>
+      <trkpt lat="52.096438407897949" lon="5.243654251098633"/>
+      <trkpt lat="52.095794677734375" lon="5.243461132049561"/>
+      <trkpt lat="52.095773220062256" lon="5.243418216705322"/>
+      <trkpt lat="52.095687389373779" lon="5.243268013000488"/>
+      <trkpt lat="52.095644474029541" lon="5.243310928344727"/>
+      <trkpt lat="52.095580101013184" lon="5.243375301361084"/>
+      <trkpt lat="52.095451354980469" lon="5.243418216705322"/>
+      <trkpt lat="52.095258235931396" lon="5.243439674377441"/>
+      <trkpt lat="52.094335556030273" lon="5.243203639984131"/>
+      <trkpt lat="52.094120979309082" lon="5.245413780212402"/>
+      <trkpt lat="52.094099521636963" lon="5.245628356933594"/>
+      <trkpt lat="52.093820571899414" lon="5.248739719390869"/>
+      <trkpt lat="52.093756198883057" lon="5.249319076538086"/>
+      <trkpt lat="52.09367036819458" lon="5.250070095062256"/>
+      <trkpt lat="52.09367036819458" lon="5.25022029876709"/>
+      <trkpt lat="52.093605995178223" lon="5.250670909881592"/>
+      <trkpt lat="52.093498706817627" lon="5.251915454864502"/>
+      <trkpt lat="52.090559005737305" lon="5.250520706176758"/>
+      <trkpt lat="52.090451717376709" lon="5.250499248504639"/>
+      <trkpt lat="52.090387344360352" lon="5.250499248504639"/>
+      <trkpt lat="52.090280055999756" lon="5.250391960144043"/>
+      <trkpt lat="52.090237140655518" lon="5.250391960144043"/>
+      <trkpt lat="52.09017276763916" lon="5.250413417816162"/>
+      <trkpt lat="52.090129852294922" lon="5.250434875488281"/>
+      <trkpt lat="52.089657783508301" lon="5.249748229980469"/>
+      <trkpt lat="52.088799476623535" lon="5.248503684997559"/>
+      <trkpt lat="52.088713645935059" lon="5.248417854309082"/>
+      <trkpt lat="52.088606357574463" lon="5.248289108276367"/>
+      <trkpt lat="52.088584899902344" lon="5.24822473526001"/>
+      <trkpt lat="52.087833881378174" lon="5.247194766998291"/>
+      <trkpt lat="52.087533473968506" lon="5.246765613555908"/>
+      <trkpt lat="52.086653709411621" lon="5.24547815322876"/>
+      <trkpt lat="52.085731029510498" lon="5.244147777557373"/>
+      <trkpt lat="52.085323333740234" lon="5.243568420410156"/>
+      <trkpt lat="52.084701061248779" lon="5.242710113525391"/>
+      <trkpt lat="52.08467960357666" lon="5.242645740509033"/>
+      <trkpt lat="52.084615230560303" lon="5.242624282836914"/>
+      <trkpt lat="52.08418607711792" lon="5.242002010345459"/>
+      <trkpt lat="52.083477973937988" lon="5.240950584411621"/>
+      <trkpt lat="52.083027362823486" lon="5.240306854248047"/>
+      <trkpt lat="52.082855701446533" lon="5.240070819854736"/>
+      <trkpt lat="52.082576751708984" lon="5.239641666412354"/>
+      <trkpt lat="52.082533836364746" lon="5.239555835723877"/>
+      <trkpt lat="52.082040309906006" lon="5.238826274871826"/>
+      <trkpt lat="52.081997394561768" lon="5.238783359527588"/>
+      <trkpt lat="52.0816969871521" lon="5.238332748413086"/>
+      <trkpt lat="52.081482410430908" lon="5.238010883331299"/>
+      <trkpt lat="52.081396579742432" lon="5.237946510314941"/>
+      <trkpt lat="52.081310749053955" lon="5.237903594970703"/>
+      <trkpt lat="52.081289291381836" lon="5.237860679626465"/>
+      <trkpt lat="52.080559730529785" lon="5.236830711364746"/>
+      <trkpt lat="52.079422473907471" lon="5.23524284362793"/>
+      <trkpt lat="52.079336643218994" lon="5.235414505004883"/>
+      <trkpt lat="52.079315185546875" lon="5.235457420349121"/>
+      <trkpt lat="52.079272270202637" lon="5.235521793365479"/>
+      <trkpt lat="52.078971862792969" lon="5.236079692840576"/>
+      <trkpt lat="52.078607082366943" lon="5.23674488067627"/>
+      <trkpt lat="52.078542709350586" lon="5.236873626708984"/>
+      <trkpt lat="52.078521251678467" lon="5.236916542053223"/>
+      <trkpt lat="52.078478336334229" lon="5.23698091506958"/>
+      <trkpt lat="52.078421674668789" lon="5.237075462937355"/>
+      <trkpt lat="52.078456878662109" lon="5.237131118774414"/>
+      <trkpt lat="52.078421674668789" lon="5.237075462937355"/>
+      <trkpt lat="52.078478336334229" lon="5.23698091506958"/>
+      <trkpt lat="52.078521251678467" lon="5.236916542053223"/>
+      <trkpt lat="52.078542709350586" lon="5.236873626708984"/>
+      <trkpt lat="52.077834606170654" lon="5.235843658447266"/>
+      <trkpt lat="52.077598571777344" lon="5.235521793365479"/>
+      <trkpt lat="52.077577114105225" lon="5.23547887802124"/>
+      <trkpt lat="52.077469825744629" lon="5.235328674316406"/>
+      <trkpt lat="52.077405452728271" lon="5.235199928283691"/>
+      <trkpt lat="52.077341079711914" lon="5.235114097595215"/>
+      <trkpt lat="52.077469825744629" lon="5.234470367431641"/>
+      <trkpt lat="52.077491283416748" lon="5.234105587005615"/>
+      <trkpt lat="52.07744836807251" lon="5.233547687530518"/>
+      <trkpt lat="52.07744836807251" lon="5.233161449432373"/>
+      <trkpt lat="52.077512741088867" lon="5.232839584350586"/>
+      <trkpt lat="52.077512741088867" lon="5.232753753662109"/>
+      <trkpt lat="52.077512741088867" lon="5.232667922973633"/>
+      <trkpt lat="52.077598571777344" lon="5.232431888580322"/>
+      <trkpt lat="52.076740264892578" lon="5.23123025894165"/>
+      <trkpt lat="52.075924873352051" lon="5.230071544647217"/>
+      <trkpt lat="52.075860500335693" lon="5.229814052581787"/>
+      <trkpt lat="52.075796127319336" lon="5.229728221893311"/>
+      <trkpt lat="52.075731754302979" lon="5.229663848876953"/>
+      <trkpt lat="52.075753211975098" lon="5.229535102844238"/>
+      <trkpt lat="52.075753211975098" lon="5.229449272155762"/>
+      <trkpt lat="52.075731754302979" lon="5.229406356811523"/>
+      <trkpt lat="52.07568883895874" lon="5.229363441467285"/>
+      <trkpt lat="52.075624465942383" lon="5.229320526123047"/>
+      <trkpt lat="52.075538635253906" lon="5.229320526123047"/>
+      <trkpt lat="52.075474262237549" lon="5.229299068450928"/>
+      <trkpt lat="52.07343578338623" lon="5.226423740386963"/>
+      <trkpt lat="52.068886756896973" lon="5.219879150390625"/>
+      <trkpt lat="52.068736553192139" lon="5.219492912292481"/>
+      <trkpt lat="52.068629264831543" lon="5.219106674194336"/>
+      <trkpt lat="52.068564891815186" lon="5.218677520751953"/>
+      <trkpt lat="52.068564891815186" lon="5.218141078948975"/>
+      <trkpt lat="52.068607807159424" lon="5.217647552490234"/>
+      <trkpt lat="52.068779468536377" lon="5.217068195343018"/>
+      <trkpt lat="52.069101333618164" lon="5.216274261474609"/>
+      <trkpt lat="52.070066928863525" lon="5.214107036590576"/>
+      <trkpt lat="52.070109844207764" lon="5.213999748229981"/>
+      <trkpt lat="52.070088386535645" lon="5.21376371383667"/>
+      <trkpt lat="52.068071365356445" lon="5.208613872528076"/>
+      <trkpt lat="52.068114280700684" lon="5.208442211151123"/>
+      <trkpt lat="52.068114280700684" lon="5.20827054977417"/>
+      <trkpt lat="52.068157196044922" lon="5.208098888397217"/>
+      <trkpt lat="52.068328857421875" lon="5.207540988922119"/>
+      <trkpt lat="52.068371772766113" lon="5.207369327545166"/>
+      <trkpt lat="52.068607807159424" lon="5.206575393676758"/>
+      <trkpt lat="52.068779468536377" lon="5.206081867218018"/>
+      <trkpt lat="52.069058418273926" lon="5.205459594726563"/>
+      <trkpt lat="52.069487571716309" lon="5.20453691482544"/>
+      <trkpt lat="52.069530487060547" lon="5.204215049743652"/>
+      <trkpt lat="52.069530487060547" lon="5.204215049743652"/>
+      <trkpt lat="52.06944465637207" lon="5.204000473022461"/>
+      <trkpt lat="52.071976661682129" lon="5.199859142303467"/>
+      <trkpt lat="52.07294225692749" lon="5.198249816894531"/>
+      <trkpt lat="52.073071002960205" lon="5.198121070861816"/>
+      <trkpt lat="52.073137806728482" lon="5.198096008971334"/>
+      <trkpt lat="52.073414325714111" lon="5.197992324829102"/>
+      <trkpt lat="52.073822021484375" lon="5.197863578796387"/>
+      <trkpt lat="52.074272632598877" lon="5.197691917419434"/>
+      <trkpt lat="52.076504230499268" lon="5.196962356567383"/>
+      <trkpt lat="52.076826095581055" lon="5.196833610534668"/>
+      <trkpt lat="52.076976299285889" lon="5.196490287780762"/>
+      <trkpt lat="52.077264552935958" lon="5.195337440818548"/>
+      <trkpt lat="52.077255249023438" lon="5.195331573486328"/>
+      <trkpt lat="52.077236976474524" lon="5.195399718359113"/>
+      <trkpt lat="52.077643666416407" lon="5.194373270496726"/>
+      <trkpt lat="52.077616676688194" lon="5.194373270496726"/>
+      <trkpt lat="52.077893614768982" lon="5.192654980346561"/>
+      <trkpt lat="52.077575773000717" lon="5.191045319661498"/>
+      <trkpt lat="52.077548783272505" lon="5.191045319661498"/>
+      <trkpt lat="52.077287267893553" lon="5.189282102510333"/>
+      <trkpt lat="52.076921230182052" lon="5.1873152051121"/>
+      <trkpt lat="52.076921230182052" lon="5.184984114021063"/>
+      <trkpt lat="52.076423764228821" lon="5.182104092091322"/>
+      <trkpt lat="52.076207930222154" lon="5.181691618636251"/>
+      <trkpt lat="52.074527945369482" lon="5.183581737801433"/>
+      <trkpt lat="52.074187723919749" lon="5.183215197175741"/>
+      <trkpt lat="52.070875866338611" lon="5.177184753119946"/>
+      <trkpt lat="52.070976700633764" lon="5.176695417612791"/>
+      <trkpt lat="52.073883796110749" lon="5.172570263966918"/>
+      <trkpt lat="52.077064141631126" lon="5.16587371006608"/>
+      <trkpt lat="52.078614542260766" lon="5.162414917722344"/>
+      <trkpt lat="52.079929327592254" lon="5.161528531461954"/>
+      <trkpt lat="52.08148249424994" lon="5.159287545830011"/>
+      <trkpt lat="52.08148249424994" lon="5.159243457019329"/>
+      <trkpt lat="52.081788685172796" lon="5.157927162945271"/>
+      <trkpt lat="52.082601562142372" lon="5.156325297430158"/>
+      <trkpt lat="52.082689991220832" lon="5.15632001683116"/>
+      <trkpt lat="52.082689991220832" lon="5.15632001683116"/>
+      <trkpt lat="52.082629976794124" lon="5.156209962442517"/>
+      <trkpt lat="52.082719998434186" lon="5.156069984659553"/>
+      <trkpt lat="52.08275000564754" lon="5.156030002981424"/>
+      <trkpt lat="52.084520012140274" lon="5.153339998796582"/>
+      <trkpt lat="52.084539961069822" lon="5.153230028226972"/>
+      <trkpt lat="52.084529986605048" lon="5.153200021013618"/>
+      <trkpt lat="52.084529986605048" lon="5.153200021013618"/>
+      <trkpt lat="52.0845100376755" lon="5.153109999373555"/>
+      <trkpt lat="52.084030006080866" lon="5.152120012789965"/>
+      <trkpt lat="52.083999998867512" lon="5.152009958401322"/>
+      <trkpt lat="52.083999998867512" lon="5.151869980618358"/>
+      <trkpt lat="52.084050038829446" lon="5.150889968499541"/>
+      <trkpt lat="52.084599975496531" lon="5.149260023608804"/>
+      <trkpt lat="52.084999959915876" lon="5.148140033707023"/>
+      <trkpt lat="52.085119988769293" lon="5.147699983790517"/>
+      <trkpt lat="52.085159970447421" lon="5.147609962150455"/>
+      <trkpt lat="52.085154773667455" lon="5.147664779797196">
+        <time>2016-11-07T16:05:52Z</time>
+      </trkpt>
+      <trkpt lat="52.086621606722474" lon="5.143078453838825"/>
+      <trkpt lat="52.086823778226972" lon="5.142298182472587"/>
+      <trkpt lat="52.085915682837367" lon="5.1411456707865"/>
+      <trkpt lat="52.085512513294816" lon="5.139705827459693"/>
+      <trkpt lat="52.085698591545224" lon="5.139512121677399"/>
+      <trkpt lat="52.085797162726521" lon="5.139262676239014"/>
+      <trkpt lat="52.085698591545224" lon="5.138920526951551"/>
+      <trkpt lat="52.085447385907173" lon="5.138727407902479"/>
+      <trkpt lat="52.085168519988656" lon="5.138772753998637"/>
+      <trkpt lat="52.084556221961975" lon="5.138471592217684"/>
+      <trkpt lat="52.084356397390366" lon="5.138565637171269"/>
+      <trkpt lat="52.083883071318269" lon="5.139149101451039"/>
+      <trkpt lat="52.082602735608816" lon="5.140379061922431"/>
+      <trkpt lat="52.081877700984478" lon="5.140753230080009"/>
+      <trkpt lat="52.079964112490416" lon="5.141101833432913"/>
+      <trkpt lat="52.078805817291141" lon="5.141222113743424"/>
+      <trkpt lat="52.077977936714888" lon="5.14132839627564"/>
+      <trkpt lat="52.076191250234842" lon="5.14006725512445"/>
+      <trkpt lat="52.075841976329684" lon="5.139535674825311"/>
+      <trkpt lat="52.075566630810499" lon="5.139350267127156"/>
+      <trkpt lat="52.07620482891798" lon="5.136597482487559"/>
+      <trkpt lat="52.078056475147605" lon="5.130662759765983"/>
+      <trkpt lat="52.07895627245307" lon="5.127782737836242"/>
+      <trkpt lat="52.078965241089463" lon="5.127782737836242"/>
+      <trkpt lat="52.079899488016963" lon="5.126330908387899"/>
+      <trkpt lat="52.080884110182524" lon="5.124294525012374"/>
+      <trkpt lat="52.081101536750793" lon="5.124336099252105"/>
+      <trkpt lat="52.081266911700368" lon="5.124388569965959"/>
+      <trkpt lat="52.081383755430579" lon="5.124215232208371"/>
+      <trkpt lat="52.081692712381482" lon="5.12396452948451"/>
+      <trkpt lat="52.081917095929384" lon="5.123894205316901"/>
+      <trkpt lat="52.082541966810822" lon="5.123429847881198"/>
+      <trkpt lat="52.08310472778976" lon="5.123429847881198"/>
+      <trkpt lat="52.083810903131962" lon="5.125798238441348"/>
+      <trkpt lat="52.083912407979369" lon="5.125945089384913">
+        <time>2016-11-21T09:00:05Z</time>
+      </trkpt>
+      <trkpt lat="52.083912407979369" lon="5.125959757715464"/>
+      <trkpt lat="52.084067137911916" lon="5.126384384930134"/>
+      <trkpt lat="52.084664264693856" lon="5.125776194036007"/>
+      <trkpt lat="52.085788529366255" lon="5.124658131971955"/>
+      <trkpt lat="52.086908100172877" lon="5.123831173405051"/>
+      <trkpt lat="52.088337047025561" lon="5.122876977548003"/>
+      <trkpt lat="52.090288354083896" lon="5.12177936732769"/>
+      <trkpt lat="52.090300926938653" lon="5.12177936732769"/>
+      <trkpt lat="52.090845918282866" lon="5.121498657390475"/>
+      <trkpt lat="52.09102344699204" lon="5.121666882187128"/>
+      <trkpt lat="52.091160742565989" lon="5.122291082516313"/>
+      <trkpt lat="52.091298624873161" lon="5.122351851314306"/>
+      <trkpt lat="52.09176323376596" lon="5.122337099164724"/>
+      <trkpt lat="52.092614835128188" lon="5.12197382748127"/>
+      <trkpt lat="52.092854557558894" lon="5.121911130845547"/>
+      <trkpt lat="52.093058992177248" lon="5.121746761724353"/>
+      <trkpt lat="52.093177428469062" lon="5.121418610215187"/>
+      <trkpt lat="52.093370212242007" lon="5.120652420446277"/>
+      <trkpt lat="52.093582944944501" lon="5.11903177946806"/>
+      <trkpt lat="52.093530222773552" lon="5.117861330509186"/>
+      <trkpt lat="52.093429639935493" lon="5.116956336423755"/>
+      <trkpt lat="52.093975972384214" lon="5.116848209872842"/>
+      <trkpt lat="52.094849199056625" lon="5.11683295480907"/>
+      <trkpt lat="52.095394693315029" lon="5.116776628419757"/>
+      <trkpt lat="52.09622441790998" lon="5.116275222972035"/>
+      <trkpt lat="52.096644937992096" lon="5.116002475842834"/>
+      <trkpt lat="52.097151288762689" lon="5.115426303818822"/>
+      <trkpt lat="52.098940741270781" lon="5.113701308146119"/>
+      <trkpt lat="52.099810028448701" lon="5.113063026219606"/>
+      <trkpt lat="52.100090403109789" lon="5.11293713003397"/>
+      <trkpt lat="52.10038410499692" lon="5.112562961876392"/>
+      <trkpt lat="52.100756512954831" lon="5.11242994107306"/>
+      <trkpt lat="52.102010529488325" lon="5.112220058217645"/>
+      <trkpt lat="52.10246566683054" lon="5.112055689096451"/>
+      <trkpt lat="52.103304108604789" lon="5.111532490700483"/>
+      <trkpt lat="52.103980528190732" lon="5.111097553744912"/>
+      <trkpt lat="52.104468187317252" lon="5.11061861179769"/>
+      <trkpt lat="52.104727439582348" lon="5.110204797238112"/>
+      <trkpt lat="52.105175452306867" lon="5.109164267778397"/>
+      <trkpt lat="52.105388687923551" lon="5.108922868967056"/>
+      <trkpt lat="52.106575146317482" lon="5.108346026390791"/>
+      <trkpt lat="52.106609093025327" lon="5.10813245549798"/>
+      <trkpt lat="52.106485208496451" lon="5.107606742531061"/>
+      <trkpt lat="52.106571961194277" lon="5.107490988448262"/>
+      <trkpt lat="52.108356719836593" lon="5.106140244752169"/>
+      <trkpt lat="52.108579678460956" lon="5.106126163154841"/>
+      <trkpt lat="52.108923839405179" lon="5.105697680264711"/>
+      <trkpt lat="52.111058542504907" lon="5.102414069697261"/>
+      <trkpt lat="52.113220989704132" lon="5.099372109398246"/>
+      <trkpt lat="52.113229958340526" lon="5.099372109398246"/>
+      <trkpt lat="52.113567078486085" lon="5.09874346666038"/>
+      <trkpt lat="52.114579109475017" lon="5.097212260589004"/>
+      <trkpt lat="52.115958351641893" lon="5.095470501109958"/>
+      <trkpt lat="52.117364080622792" lon="5.094447154551745"/>
+      <trkpt lat="52.117898259311914" lon="5.093684736639261"/>
+      <trkpt lat="52.118261195719242" lon="5.092575056478381"/>
+      <trkpt lat="52.118523130193353" lon="5.090749058872461"/>
+      <trkpt lat="52.118476191535592" lon="5.09039668366313"/>
+      <trkpt lat="52.11850636638701" lon="5.089794779196382"/>
+      <trkpt lat="52.118933340534568" lon="5.086606722325087"/>
+      <trkpt lat="52.119036186486483" lon="5.08589786477387"/>
+      <trkpt lat="52.119107348844409" lon="5.084945010021329"/>
+      <trkpt lat="52.11923441849649" lon="5.084806876257062"/>
+      <trkpt lat="52.119855768978596" lon="5.084938555955887"/>
+      <trkpt lat="52.120014941319823" lon="5.085076689720154"/>
+      <trkpt lat="52.120104879140854" lon="5.085133602842689"/>
+      <trkpt lat="52.120113847777247" lon="5.085133602842689"/>
+      <trkpt lat="52.120222896337509" lon="5.08501592092216"/>
+      <trkpt lat="52.121096877381206" lon="5.081978738307953"/>
+      <trkpt lat="52.121260911226273" lon="5.081902043893933"/>
+      <trkpt lat="52.121926853433251" lon="5.082258861511946"/>
+      <trkpt lat="52.122704274952412" lon="5.083264857530594"/>
+      <trkpt lat="52.12286839261651" lon="5.083312215283513"/>
+      <trkpt lat="52.127199154347181" lon="5.07563715800643"/>
+      <trkpt lat="52.127199154347181" lon="5.075495922937989"/>
+      <trkpt lat="52.125573819503188" lon="5.07268681190908"/>
+      <trkpt lat="52.126909643411636" lon="5.071035493165255"/>
+      <trkpt lat="52.127489503473043" lon="5.070178443565965"/>
+    </trkseg>
+  </trk>
+
+</gpx>

--- a/tests/segment_test.rb
+++ b/tests/segment_test.rb
@@ -6,6 +6,7 @@ require 'gpx'
 class SegmentTest < Minitest::Test
    ONE_SEGMENT = File.join(File.dirname(__FILE__), "gpx_files/one_segment.gpx")
    ONE_SEGMENT_NO_TIME = File.join(File.dirname(__FILE__), "gpx_files/one_segment_no_time.gpx")
+   ONE_SEGMENT_MIXED_TIMES = File.join(File.dirname(__FILE__), "gpx_files/one_segment_mixed_times.gpx")
 
    def setup
       @gpx_file = GPX::GPXFile.new(:gpx_file => ONE_SEGMENT)
@@ -104,6 +105,16 @@ class SegmentTest < Minitest::Test
       assert_equal(1480.087, @segment.highest_point.elevation)
       assert_in_delta(6.900813095, @segment.distance, 0.001)
       assert_equal(4466.0, @segment.duration)
+   end
+
+   def test_segment_mixed_times
+      gpx_file_mixed_times = GPX::GPXFile.new(:gpx_file => ONE_SEGMENT_MIXED_TIMES)
+      segment_mixed_times = gpx_file_mixed_times.tracks.first.segments.first
+      assert_equal(588, segment_mixed_times.points.size)
+      assert_equal(0, segment_mixed_times.earliest_point.time.to_i)
+      assert_equal(0, segment_mixed_times.latest_point.time.to_i)
+      assert_in_delta(40.763726054, segment_mixed_times.distance, 0.001)
+      assert_equal(0.0, segment_mixed_times.duration)
    end
 
 end


### PR DESCRIPTION
I have a GPX file with mixed tracking points, as some of them have a time node and others do not. If the first tracking point of a segment does not have a time node it gets set as the earliest_point. But when a point gets added, that does have a time node attached to it, an ArgumentError is raised because the time of the first tracking point is nil.

