### PR TITLE
Ignore empty segments

### DIFF
--- a/lib/gpx/track.rb
+++ b/lib/gpx/track.rb
@@ -45,16 +45,17 @@ module GPX
         @description = (trk_element.at('desc').inner_text rescue '')
         trk_element.search("trkseg").each do |seg_element|
           seg = Segment.new(:element => seg_element, :track => self, :gpx_file => @gpx_file)
-          update_meta_data(seg)
-          @segments << seg
+          append_segment(seg)
         end
       end
     end
 
     # Append a segment to this track, updating its meta data along the way.
     def append_segment(seg)
-      update_meta_data(seg)
-      @segments << seg
+      if seg.points.size > 0
+        update_meta_data(seg)
+        @segments << seg
+      end
     end
 
     # Returns true if the given time occurs within any of the segments of this track.

--- a/tests/gpx_file_test.rb
+++ b/tests/gpx_file_test.rb
@@ -5,6 +5,7 @@ class GPXFileTest < Minitest::Test
 
   ONE_TRACK_FILE = File.join(File.dirname(__FILE__), "gpx_files/one_track.gpx")
   WITH_OR_WITHOUT_ELEV_FILE = File.join(File.dirname(__FILE__), "gpx_files/with_or_without_elev.gpx")
+  WITH_EMPTY_TRACKS = File.join(File.dirname(__FILE__), "gpx_files/with_empty_tracks.gpx")
   BIG_FILE = File.join(File.dirname(__FILE__), "gpx_files/big.gpx")
 
   def test_load_data_from_string
@@ -60,6 +61,17 @@ class GPXFileTest < Minitest::Test
     assert_equal(0, gpx_file.moving_duration)
     assert(gpx_file.average_speed.nan?)
     #assert_equal(7968, gpx_file.tracks.first.points.size)
+  end
+
+  def test_with_empty_tracks
+    gpx_file = GPX::GPXFile.new(:gpx_file => WITH_EMPTY_TRACKS)
+    # is read correctly
+    assert_equal(1, gpx_file.tracks.size)
+    # and ignores empty segments
+    assert_equal(1, gpx_file.tracks.first.segments.size)
+    assert_equal(21.0, gpx_file.duration)
+    assert_equal(21.0, gpx_file.moving_duration)
+    assert_equal(6.674040636626879, gpx_file.average_speed)
   end
 
 end

--- a/tests/gpx_files/with_empty_tracks.gpx
+++ b/tests/gpx_files/with_empty_tracks.gpx
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="Open GPX Tracker for iOS">
+	<wpt lat="51.185170" lon="4.662453">
+		<time>2018-01-16T11:35:01Z</time>
+		<name>12:35:01</name>
+		<desc>16 jan. 2018 12:35:01</desc>
+	</wpt>
+	<trk>
+		<trkseg>
+			<trkpt lat="51.183019" lon="4.664619">
+				<ele>0.751247</ele>
+				<time>2018-01-16T11:06:00Z</time>
+			</trkpt>
+			<trkpt lat="51.183037" lon="4.664587">
+				<ele>0.622036</ele>
+				<time>2018-01-16T11:06:02Z</time>
+			</trkpt>
+			<trkpt lat="51.183053" lon="4.664553">
+				<ele>0.042019</ele>
+				<time>2018-01-16T11:06:04Z</time>
+			</trkpt>
+			<trkpt lat="51.183073" lon="4.664515">
+				<ele>0.177456</ele>
+				<time>2018-01-16T11:06:06Z</time>
+			</trkpt>
+			<trkpt lat="51.183095" lon="4.664480">
+				<ele>0.564846</ele>
+				<time>2018-01-16T11:06:08Z</time>
+			</trkpt>
+			<trkpt lat="51.183115" lon="4.664446">
+				<ele>0.941067</ele>
+				<time>2018-01-16T11:06:10Z</time>
+			</trkpt>
+			<trkpt lat="51.183143" lon="4.664401">
+				<ele>1.960781</ele>
+				<time>2018-01-16T11:06:12Z</time>
+			</trkpt>
+			<trkpt lat="51.183160" lon="4.664372">
+				<ele>2.115200</ele>
+				<time>2018-01-16T11:06:13Z</time>
+			</trkpt>
+			<trkpt lat="51.183176" lon="4.664342">
+				<ele>2.191250</ele>
+				<time>2018-01-16T11:06:14Z</time>
+			</trkpt>
+			<trkpt lat="51.183192" lon="4.664315">
+				<ele>2.492947</ele>
+				<time>2018-01-16T11:06:15Z</time>
+			</trkpt>
+			<trkpt lat="51.183205" lon="4.664291">
+				<ele>2.459927</ele>
+				<time>2018-01-16T11:06:16Z</time>
+			</trkpt>
+			<trkpt lat="51.183217" lon="4.664270">
+				<ele>2.226833</ele>
+				<time>2018-01-16T11:06:17Z</time>
+			</trkpt>
+			<trkpt lat="51.183240" lon="4.664233">
+				<ele>2.175198</ele>
+				<time>2018-01-16T11:06:19Z</time>
+			</trkpt>
+			<trkpt lat="51.183255" lon="4.664207">
+				<ele>2.643887</ele>
+				<time>2018-01-16T11:06:21Z</time>
+			</trkpt>
+		</trkseg>
+		<trkseg>
+		</trkseg>
+		<trkseg>
+		</trkseg>
+	</trk>
+</gpx>


### PR DESCRIPTION
I am using this library with pleasure in our software. Unfortunately a user of ours turned up with a gpx which contained empty segments at the end which caused an error. 

E.g. something like 

```
<gpx>
    <trk>
       [one or more correct segments]
        <trkseg>
        </trkseg>
        <trkseg>
        </trkseg>
    </trk>
</gpx>
```

When adding the segment to the track, the `update_meta_data` function barfed. My first solution was to only try to update the meta data if the segment actually contained points, but then the track also had empty segments, and not sure what the effects might be later on, so upon adding the segment I check if the segment actually contains points and only add in that case.

I added an example-file + test-case. This should have no effect imho for anybody else, it would just handle ill-formed gpx files better (well maybe ill-formed is worded too strong: but gpx files with empty segments). 