### PR TITLE
Updating Ruby test matrix with 2.5, minor patch versions of others.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.1
   - 2.2
-  - 2.3.3
-  - 2.4.0
+  - 2.3
+  - 2.4
+  - 2.5
 script: "bundle exec rake ci:build"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ etc).
 
 ## Requirements
 
-As of `0.9.0`, `gpx` requires at least Ruby 2.1 to run.
+As of `0.10.0`, `gpx` requires at least Ruby 2.2 to run.
 
 ## Examples
 


### PR DESCRIPTION
This also deprecates Ruby 2.2 from the supported Ruby matrix.