### PR TITLE
Specify UTF-8 as XML encoding

### DIFF
--- a/lib/gpx/gpx_file.rb
+++ b/lib/gpx/gpx_file.rb
@@ -260,7 +260,7 @@ module GPX
       # $stderr.puts gpx_header.keys.inspect
 
       # rubocop:disable Metrics/BlockLength
-      doc = Nokogiri::XML::Builder.new do |xml|
+      doc = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
         xml.gpx(gpx_header) do
           # version 1.0 of the schema doesn't support the metadata element, so push them straight to the root 'gpx' element
           if @version == '1.0'


### PR DESCRIPTION
The non-ASCII characters were sanitized because the XML encoding was not specified.
For compatibility with other systems, I think it's better to specify the encoding as UTF-8.

Sample code

```
gpx = GPX::GPXFile.new
gpx.waypoints << GPX::Waypoint.new(name: '日本語')
puts gpx.to_s
```

Output(not specifying UTF-8)
```
<?xml version="1.0"?>
<gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" creator="GPX RubyGem 1.0.0 -- http://dougfales.github.io/gpx/" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
  <metadata>
    <name/>
    <time>2020-06-17T15:14:55+09:00</time>
    <bound minlat="90.0" minlon="180.0" maxlat="-90.0" maxlon="-180.0"/>
  </metadata>
  <wpt lat="" lon="">
    <name>&#x65E5;&#x672C;&#x8A9E;</name>
  </wpt>
</gpx>
```

Output(not specifying UTF-8)
```
<?xml version="1.0" encoding="UTF-8"?>
<gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" creator="GPX RubyGem 1.0.0 -- http://dougfales.github.io/gpx/" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
  <metadata>
    <name/>
    <time>2020-06-17T15:14:23+09:00</time>
    <bound minlat="90.0" minlon="180.0" maxlat="-90.0" maxlon="-180.0"/>
  </metadata>
  <wpt lat="" lon="">
    <name>日本語</name>
  </wpt>
</gpx>
```