### PR TITLE
Fix some schema validation issues

### DIFF
--- a/lib/gpx/bounds.rb
+++ b/lib/gpx/bounds.rb
@@ -4,7 +4,7 @@ module GPX
 
     # Creates a new bounds object with the passed-in min and max longitudes
     # and latitudes.
-    def initialize(opts = { min_lat: 90.0, max_lat: -90.0, min_lon: 180.0, max_lon: -180.0 })
+    def initialize(opts = { min_lat: 90.0, max_lat: -90.0, min_lon: 179.99, max_lon: -179.99 })
       @min_lat = opts[:min_lat].to_f
       @max_lat = opts[:max_lat].to_f
       @min_lon = opts[:min_lon].to_f

--- a/lib/gpx/gpx_file.rb
+++ b/lib/gpx/gpx_file.rb
@@ -256,6 +256,7 @@ module GPX
       gpx_header['creator'] = DEFAULT_CREATOR unless gpx_header['creator']
       gpx_header['xsi:schemaLocation'] = "http://www.topografix.com/GPX/#{version_dir} http://www.topografix.com/GPX/#{version_dir}/gpx.xsd" unless gpx_header['xsi:schemaLocation']
       gpx_header['xmlns:xsi'] = 'http://www.w3.org/2001/XMLSchema-instance' if !gpx_header['xsi'] && !gpx_header['xmlns:xsi']
+      gpx_header['xmlns'] = "http://www.topografix.com/GPX/#{version_dir}"
 
       # $stderr.puts gpx_header.keys.inspect
 
@@ -276,7 +277,7 @@ module GPX
             xml.metadata do
               xml.name @name
               xml.time @time.xmlschema
-              xml.bound(
+              xml.bounds(
                 minlat: bounds.min_lat,
                 minlon: bounds.min_lon,
                 maxlat: bounds.max_lat,


### PR DESCRIPTION
I had some issues while importing GPX data created with this gem into my mobile app (c-geo).

After validating with https://www.corefiling.com/opensource/schemavalidate/, i've stated three problems:

1 - Default namespace was missing
2 - Bounds element must be pluralized inside metadata element
3 - Bounds max values must be extrictly smaller than 180, so 179.99 is good

Tested again with c-geo and waypoints now imports data successfully