### PR TITLE
Adds top level xmlns declaration

### DIFF
--- a/lib/gpx/gpx_file.rb
+++ b/lib/gpx/gpx_file.rb
@@ -258,6 +258,7 @@ module GPX
 
       gpx_header['version'] = @version.to_s unless gpx_header['version']
       gpx_header['creator'] = DEFAULT_CREATOR unless gpx_header['creator']
+      gpx_header['xmlns'] = "http://www.topografix.com/GPX/#{version_dir}" unless gpx_header['xsi:schemaLocation']
       gpx_header['xsi:schemaLocation'] = "http://www.topografix.com/GPX/#{version_dir} http://www.topografix.com/GPX/#{version_dir}/gpx.xsd" unless gpx_header['xsi:schemaLocation']
       gpx_header['xmlns:xsi'] = 'http://www.w3.org/2001/XMLSchema-instance' if !gpx_header['xsi'] && !gpx_header['xmlns:xsi']
 


### PR DESCRIPTION
A top level xmlns declaration is required to be a valid gpx file, according to the GPX spec:

 - https://www.topografix.com/GPX/1/1/#SchemaProperties
  - https://www.topografix.com/gpx_manual.asp

This pull request rectifies this issue.