### PR TITLE
Fix nil method call when <rte>-based GPX omits <name> tags

### DIFF
--- a/lib/gpx/route.rb
+++ b/lib/gpx/route.rb
@@ -13,7 +13,7 @@ module GPX
       if opts[:gpx_file] && opts[:element]
         rte_element = opts[:element]
         @gpx_file = opts[:gpx_file]
-        @name = rte_element.at('name').inner_text
+        @name = rte_element.at('name')&.inner_text
         @points = []
         rte_element.search('rtept').each do |point|
           @points << Point.new(element: point, gpx_file: @gpx_file)

--- a/tests/gpx_files/routes_without_names.gpx
+++ b/tests/gpx_files/routes_without_names.gpx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="Link2GPS - 2.0.2 - http://www.hiketech.com" xsi:schemaLocation="ttp://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+  <metadata>
+    <name><![CDATA[routes.gpx]]></name>
+    <time>2006-01-02T08:55:34Z</time>
+    <bounds min_lat="39.989739" min_lon="-105.295285" max_lat="39.999840" max_lon="-105.214696"/>
+  </metadata>
+  <extensions/>
+  <rte>
+    <rtept lat="39.997298" lon="-105.292674">
+      <sym>Waypoint</sym>
+      <ele>1766.535</ele>
+    </rtept>
+    <rtept lat="39.995700" lon="-105.292805">
+      <sym>Waypoint</sym>
+      <ele>1854.735</ele>
+    </rtept>
+    <rtept lat="39.989739" lon="-105.295285">
+      <sym>Waypoint</sym>
+      <ele>2163.556</ele>
+    </rtept>
+  </rte>
+  <rte>
+    <rtept lat="39.999840" lon="-105.214696">
+      <sym>Waypoint</sym>
+      <ele>1612.965</ele>
+    </rtept>
+  </rte>
+</gpx>

--- a/tests/route_test.rb
+++ b/tests/route_test.rb
@@ -55,4 +55,54 @@ class RouteTest < Minitest::Test
     assert_equal(-105.214696, second_route.points[0].lon)
     assert_equal(1612.965,    second_route.points[0].elevation)
   end
+
+  def test_read_routes_without_name_fields
+    file = File.join(File.dirname(__FILE__), 'gpx_files/routes_without_names.gpx')
+    gpx = GPX::GPXFile.new(gpx_file: file)
+    assert_equal(2, gpx.routes.size)
+    first_route = gpx.routes.first
+    assert_equal(3, first_route.points.size)
+    assert_nil(first_route.name)
+
+    # Route 1, First Point
+    # <rtept lat="39.997298" lon="-105.292674">
+    #  <sym>Waypoint</sym>
+    #  <ele>1766.535</ele>
+    # </rtept>
+    assert_equal(39.997298,   first_route.points[0].lat)
+    assert_equal(-105.292674, first_route.points[0].lon)
+    assert_equal(1766.535,    first_route.points[0].elevation)
+
+    # Route 1, Second Point
+    # <rtept lat="39.995700" lon="-105.292805">
+    #  <name><![CDATA[AMPTHT]]></name>
+    #  <sym>Waypoint</sym>
+    #  <ele>1854.735</ele>
+    # </rtept>
+    assert_equal(39.995700,   first_route.points[1].lat)
+    assert_equal(-105.292805, first_route.points[1].lon)
+    assert_equal(1854.735,    first_route.points[1].elevation)
+
+    # Route 1, Third Point
+    # <rtept lat="39.989739" lon="-105.295285">
+    #  <sym>Waypoint</sym>
+    #  <ele>2163.556</ele>
+    # </rtept>
+    assert_equal(39.989739,   first_route.points[2].lat)
+    assert_equal(-105.295285, first_route.points[2].lon)
+    assert_equal(2163.556,    first_route.points[2].elevation)
+
+    second_route = gpx.routes[1]
+    assert_equal(1, second_route.points.size)
+    assert_nil(second_route.name)
+
+    # Route 2, Only Point
+    # <rtept lat="39.999840" lon="-105.214696">
+    #   <sym>Waypoint</sym>
+    #   <ele>1612.965</ele>
+    # </rtept>
+    assert_equal(39.999840,   second_route.points[0].lat)
+    assert_equal(-105.214696, second_route.points[0].lon)
+    assert_equal(1612.965,    second_route.points[0].elevation)
+  end
 end


### PR DESCRIPTION
Simple fix for when there is no name tag for a rte.