### PR TITLE
Fix gpx route with no name

### DIFF
--- a/lib/gpx/route.rb
+++ b/lib/gpx/route.rb
@@ -13,7 +13,7 @@ module GPX
       if opts[:gpx_file] && opts[:element]
         rte_element = opts[:element]
         @gpx_file = opts[:gpx_file]
-        @name = rte_element.at('name').inner_text
+        @name = rte_element.at('name')&.inner_text
         @points = []
         rte_element.search('rtept').each do |point|
           @points << Point.new(element: point, gpx_file: @gpx_file)

--- a/tests/gpx_files/routes.gpx
+++ b/tests/gpx_files/routes.gpx
@@ -6,4 +6,5 @@
 <rtept lat="39.989739" lon="-105.295285"><name><![CDATA[TO]]></name><sym>Waypoint</sym><ele>2163.556</ele></rtept></rte>
 <rte><name><![CDATA[SBDR-SBDR]]></name>
 <rtept lat="39.999840" lon="-105.214696"><name><![CDATA[SBDR]]></name><sym>Waypoint</sym><ele>1612.965</ele></rtept></rte>
+<rte></rte>
 </gpx>

--- a/tests/route_test.rb
+++ b/tests/route_test.rb
@@ -6,7 +6,7 @@ require 'gpx'
 class RouteTest < Minitest::Test
   def test_read_routes
     gpx = GPX::GPXFile.new(gpx_file: File.join(File.dirname(__FILE__), 'gpx_files/routes.gpx'))
-    assert_equal(2, gpx.routes.size)
+    assert_equal(3, gpx.routes.size)
     first_route = gpx.routes.first
     assert_equal(3, first_route.points.size)
     assert_equal('GRG-CA-TO', first_route.name)
@@ -54,5 +54,10 @@ class RouteTest < Minitest::Test
     assert_equal(39.999840,   second_route.points[0].lat)
     assert_equal(-105.214696, second_route.points[0].lon)
     assert_equal(1612.965,    second_route.points[0].elevation)
+
+    # Route 3, No point, no name
+    third_route = gpx.routes[2]
+    assert_equal(0, third_route.points.size)
+    assert_nil(third_route.name)
   end
 end


### PR DESCRIPTION
On GPX with nameless route it fails with
```
lib/gpx/route.rb:16:in `initialize': undefined method `inner_text' for nil:NilClass (NoMethodError)
```

Add support for nameless route, and test.