### PR TITLE
future proofs the current ci pipeline

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,12 +24,12 @@ jobs:
         ruby-version: ['2.7', '3.0', '3.1', '3.2']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@v1.149.0
+      uses: ruby/setup-ruby@v1.159.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
As time goes on GitHub does deprecates older versions of CI actions/steps.

This PR makes the warnings thrown vanish 🪣 🧹 

- [actions/checkout@v4](https://github.com/actions/checkout) as this action currently is stuck at `v2`
- [ruby/setup-ruby@v1.159.0](https://github.com/ruby/setup-ruby/releases/tag/v1.159.0) takes care of the NodeJS warning, when setting up Ruby