### PR TITLE
Enhancing input file flexibility

### DIFF
--- a/lib/gpx/gpx_file.rb
+++ b/lib/gpx/gpx_file.rb
@@ -35,7 +35,7 @@ module GPX
       if opts[:gpx_file] || opts[:gpx_data]
         if opts[:gpx_file]
           gpx_file = opts[:gpx_file]
-          gpx_file = File.open(gpx_file) unless gpx_file.is_a?(File)
+          gpx_file = File.open(gpx_file) unless gpx_file.respond_to?(:read)
           @xml = Nokogiri::XML(gpx_file)
         else
           @xml = Nokogiri::XML(opts[:gpx_data])

--- a/tests/gpx_file_test.rb
+++ b/tests/gpx_file_test.rb
@@ -2,6 +2,7 @@
 
 require 'minitest/autorun'
 require 'gpx'
+require 'stringio'
 
 class GPXFileTest < Minitest::Test
   ONE_TRACK_FILE = File.join(File.dirname(__FILE__), 'gpx_files/one_track.gpx')
@@ -11,39 +12,12 @@ class GPXFileTest < Minitest::Test
 
   def test_load_data_from_string
     gpx_file = GPX::GPXFile.new(gpx_data: File.open(ONE_TRACK_FILE).read)
-    assert_equal(1, gpx_file.tracks.size)
-    assert_equal(8, gpx_file.tracks.first.segments.size)
-    assert_equal('ACTIVE LOG', gpx_file.tracks.first.name)
-    assert_equal('active_log.gpx', gpx_file.name)
-    assert_equal('2006-04-08T16:44:28Z', gpx_file.time.xmlschema)
-    assert_equal(38.681488, gpx_file.bounds.min_lat)
-    assert_equal(-109.606948, gpx_file.bounds.min_lon)
-    assert_equal(38.791759, gpx_file.bounds.max_lat)
-    assert_equal(-109.447045, gpx_file.bounds.max_lon)
-    assert_equal('description of my GPX file with special char like &, <, >', gpx_file.description)
-    assert_equal('description of my GPX file with special char like &, <, >', gpx_file.description)
-    assert_equal(3.0724966849262554, gpx_file.distance)
-    assert_equal(15_237.0, gpx_file.duration)
-    assert_equal(3036.0, gpx_file.moving_duration)
-    assert_equal(3.6432767014935834, gpx_file.average_speed)
+    shared_assertions_for_one_track_file(gpx_file)
   end
 
   def test_load_data_from_file
     gpx_file = GPX::GPXFile.new(gpx_file: ONE_TRACK_FILE)
-    assert_equal(1, gpx_file.tracks.size)
-    assert_equal(8, gpx_file.tracks.first.segments.size)
-    assert_equal('ACTIVE LOG', gpx_file.tracks.first.name)
-    assert_equal('active_log.gpx', gpx_file.name)
-    assert_equal('2006-04-08T16:44:28Z', gpx_file.time.xmlschema)
-    assert_equal(38.681488, gpx_file.bounds.min_lat)
-    assert_equal(-109.606948, gpx_file.bounds.min_lon)
-    assert_equal(38.791759, gpx_file.bounds.max_lat)
-    assert_equal(-109.447045, gpx_file.bounds.max_lon)
-    assert_equal('description of my GPX file with special char like &, <, >', gpx_file.description)
-    assert_equal(3.0724966849262554, gpx_file.distance)
-    assert_equal(15_237.0, gpx_file.duration)
-    assert_equal(3036.0, gpx_file.moving_duration)
-    assert_equal(3.6432767014935834, gpx_file.average_speed)
+    shared_assertions_for_one_track_file(gpx_file)
   end
 
   def test_big_file
@@ -73,5 +47,36 @@ class GPXFileTest < Minitest::Test
     assert_equal(21.0, gpx_file.duration)
     assert_equal(21.0, gpx_file.moving_duration)
     assert_equal(6.674040636626879, gpx_file.average_speed)
+  end
+
+  def test_load_data_from_stringio_assigned_gpx_file
+    str = File.open(ONE_TRACK_FILE).read
+    io = StringIO.new(str, 'r+')
+    gpx_file = GPX::GPXFile.new(gpx_file: io)
+    shared_assertions_for_one_track_file(gpx_file)
+  end
+
+  def test_load_data_from_stringio_assigned_gpx_data
+    str = File.open(ONE_TRACK_FILE).read
+    io = StringIO.new(str, 'r+')
+    gpx_file = GPX::GPXFile.new(gpx_data: io)
+    shared_assertions_for_one_track_file(gpx_file)
+  end
+
+  def shared_assertions_for_one_track_file(gpx_file)
+    assert_equal(1, gpx_file.tracks.size)
+    assert_equal(8, gpx_file.tracks.first.segments.size)
+    assert_equal('ACTIVE LOG', gpx_file.tracks.first.name)
+    assert_equal('active_log.gpx', gpx_file.name)
+    assert_equal('2006-04-08T16:44:28Z', gpx_file.time.xmlschema)
+    assert_equal(38.681488, gpx_file.bounds.min_lat)
+    assert_equal(-109.606948, gpx_file.bounds.min_lon)
+    assert_equal(38.791759, gpx_file.bounds.max_lat)
+    assert_equal(-109.447045, gpx_file.bounds.max_lon)
+    assert_equal('description of my GPX file with special char like &, <, >', gpx_file.description)
+    assert_equal(3.0724966849262554, gpx_file.distance)
+    assert_equal(15_237.0, gpx_file.duration)
+    assert_equal(3036.0, gpx_file.moving_duration)
+    assert_equal(3.6432767014935834, gpx_file.average_speed)
   end
 end


### PR DESCRIPTION
The current `GPX::GPXFile.new` requires an instance of the `File` class for the `gpx_file` option when specifying a file, but I think this should be a bit more flexible.
For instance, Issue #34 expects `StringIO` and `Tempfile` to be loaded, and I agree.

I have checked the source of `Nokogiri::XML::Document.parse` for this modification. As a result, I thought it would be better if the parameters of `GPX::GPXFile.new` were the same as the API of `Nokogiri::XML::Document.parse`, but for compatibility reasons, I concluded that the implementation as shown in this PR would be better.
Incidentally, the idea of `respond_to?(:read)` is exactly what `Nokogiri::XML::Document.parse` does.


Implementing this PR facilitates the following scenarios:

- Example: Reading from STDIN

```
$ cat tests/gpx_files/gpx10.gpx | ruby -Ilib -rgpx -e 'puts GPX::GPXFile.new(gpx_file: $stdin).tracks.first.name'
```

- Example: Reading from OpenURI (where URI.open returns a Tempfile)

```
$ ruby -Ilib -ropen-uri -rgpx -e 'puts GPX::GPXFile.new(gpx_file: URI.open("https://raw.githubusercontent.com/dougfales/gpx/v1.1.1/tests/gpx_files/gpx10.gpx")).tracks.first.name'
```

I especially wanted to use it in the pipeline from STDIN, as in the first example.
