### PR TITLE
fixes missing css gem dependency for ruby >= v3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@v1.159.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased] - YYYY-MM-DD
+
+  * changes dependencies, as `CSV` gem was loaded from the standard library, but will no longer be part of the default gems with Ruby 3.4 (#57 via @simonneutert)
+
 ## [1.2.0] - 2024-07-26
 
   * Adds ability to address various GeoJSON properties when performing GeoJSON to GPX conversion. (#53 via @niborg)
@@ -5,8 +9,8 @@
 
 ## [1.1.1] - 2023-05-19
 
-  * updates CI, minimal Ruby version now 2.7, updates tooling like rubocop and GitHub actions
-  * adds support for Ruby 3.2
+  * updates CI, minimal Ruby version now 2.7, updates tooling like rubocop and GitHub actions (#54 via @simonneutert)
+  * adds support for Ruby 3.2 (#52 via @simonneutert)
   * adds UPGRADING.md to document changes between versions
 
 ## [1.1.0] - 2023-05-18

--- a/gpx.gemspec
+++ b/gpx.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.homepage = 'http://www.github.com/dougfales/gpx'
+  s.add_dependency 'csv'
   s.add_dependency 'nokogiri', '~>1.7'
   s.add_dependency 'rake'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
> warning: csv was loaded from the standard library but will no longer be part of the default gems since Ruby 3.4.0.  Add csv to your Gemfile or gemspec.

This pull request includes updates to dependencies and documentation to ensure compatibility with future Ruby versions and proper attribution for contributions.

### Dependency Updates:
* [`gpx.gemspec`](diffhunk://#diff-02898fcab1b7d5aa20cfa17f98794d5e32f08e1d82d53efe5c111315f2e83cdaR22): Added `csv` gem as a dependency since it will no longer be part of the default gems with Ruby 3.4.

### Documentation Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R13): Updated to reflect the addition of the `csv` gem dependency and included proper attribution for previous changes.